### PR TITLE
Support finding children in properties

### DIFF
--- a/lib/src/Scene/Qt/QtScene.cpp
+++ b/lib/src/Scene/Qt/QtScene.cpp
@@ -47,11 +47,17 @@ QQuickItem* getQQuickItemWithRoot(const spix::ItemPath& path, QObject* root)
     auto itemName = path.rootComponent();
     QQuickItem* subItem = nullptr;
 
-    if (rootClassName == spix::qt::repeater_class_name) {
-        QQuickItem* repeater = static_cast<QQuickItem*>(root);
-        subItem = spix::qt::RepeaterChildWithName(repeater, QString::fromStdString(itemName));
+    if (itemName.compare(0, 1, ".") == 0) {
+        QVariant propValue = root->property(itemName.c_str() + 1);
+        if (propValue.isValid())
+            subItem = propValue.value<QQuickItem*>();
     } else {
-        subItem = root->findChild<QQuickItem*>(itemName.c_str());
+        if (rootClassName == spix::qt::repeater_class_name) {
+            QQuickItem* repeater = static_cast<QQuickItem*>(root);
+            subItem = spix::qt::RepeaterChildWithName(repeater, QString::fromStdString(itemName));
+        } else {
+            subItem = root->findChild<QQuickItem*>(itemName.c_str());
+        }
     }
 
     if (path.length() == 1) {


### PR DESCRIPTION
I'm not sure if you'll like this conceptually...

I'm trying to solve a problem of accessing objects "hidden" behind StackViews/Loaders, because `findChild()` cannot see them.

This adds support for using property names in paths - for example: `myApp/stackView/.currentItem/someButton`