### PR TITLE
Report errors in commands immediately through XML-RPC errors

### DIFF
--- a/lib/src/Commands/ClickOnItem.cpp
+++ b/lib/src/Commands/ClickOnItem.cpp
@@ -7,29 +7,35 @@
 #include "ClickOnItem.h"
 
 #include <Scene/Scene.h>
+#include <stdexcept>
 
 namespace spix {
 namespace cmd {
 
-ClickOnItem::ClickOnItem(ItemPosition path)
-: m_position(std::move(path))
+ClickOnItem::ClickOnItem(ItemPosition path, std::promise<void> promise)
+: m_position(std::move(path)), m_promise(std::move(promise))
 {
 }
 
 void ClickOnItem::execute(CommandEnvironment& env)
 {
-    auto path = m_position.itemPath();
-    auto item = env.scene().itemAtPath(path);
+    try {
+        auto path = m_position.itemPath();
+        auto item = env.scene().itemAtPath(path);
 
-    if (!item) {
-        env.state().reportError("ClickOnItem: Item not found: " + path.string());
-        return;
+        if (!item)
+            throw std::runtime_error("ClickOnItem: Item not found: " + path.string());
+
+        auto size = item->size();
+        auto mousePoint = m_position.positionForItemSize(size);
+        env.scene().events().mouseDown(item.get(), mousePoint, Events::MouseButtons::left);
+        env.scene().events().mouseUp(item.get(), mousePoint, Events::MouseButtons::left);
+
+        m_promise.set_value();
+    } catch (const std::runtime_error& e) {
+        env.state().reportError(e.what());
+        m_promise.set_exception(std::make_exception_ptr(e));
     }
-
-    auto size = item->size();
-    auto mousePoint = m_position.positionForItemSize(size);
-    env.scene().events().mouseDown(item.get(), mousePoint, Events::MouseButtons::left);
-    env.scene().events().mouseUp(item.get(), mousePoint, Events::MouseButtons::left);
 }
 
 } // namespace cmd

--- a/lib/src/Commands/ClickOnItem.h
+++ b/lib/src/Commands/ClickOnItem.h
@@ -8,18 +8,20 @@
 
 #include "Command.h"
 #include <Spix/Data/ItemPosition.h>
+#include <future>
 
 namespace spix {
 namespace cmd {
 
 class ClickOnItem : public Command {
 public:
-    ClickOnItem(ItemPosition path);
+    ClickOnItem(ItemPosition path, std::promise<void> promise);
 
     void execute(CommandEnvironment& env) override;
 
 private:
     ItemPosition m_position;
+    std::promise<void> m_promise;
 };
 
 } // namespace cmd

--- a/lib/src/Commands/DragBegin.cpp
+++ b/lib/src/Commands/DragBegin.cpp
@@ -7,28 +7,34 @@
 #include "DragBegin.h"
 
 #include <Scene/Scene.h>
+#include <stdexcept>
 
 namespace spix {
 namespace cmd {
 
-DragBegin::DragBegin(ItemPath path)
+DragBegin::DragBegin(ItemPath path, std::promise<void> promise)
 : m_path(std::move(path))
+, m_promise(std::move(promise))
 {
 }
 
 void DragBegin::execute(CommandEnvironment& env)
 {
-    auto item = env.scene().itemAtPath(m_path);
+    try {
+        auto item = env.scene().itemAtPath(m_path);
 
-    if (!item) {
-        env.state().reportError("DragBegin: Item not found: " + m_path.string());
-        return;
+        if (!item)
+            throw std::runtime_error("DragBegin: Item not found: " + m_path.string());
+
+        auto size = item->size();
+        Point midPoint(size.width / 2.0, size.height / 2.0);
+        env.scene().events().mouseDown(item.get(), midPoint, Events::MouseButtons::left);
+        env.scene().events().mouseMove(item.get(), midPoint);
+        m_promise.set_value();
+    } catch (const std::runtime_error& e) {
+        env.state().reportError(e.what());
+        m_promise.set_exception(std::make_exception_ptr(e));
     }
-
-    auto size = item->size();
-    Point midPoint(size.width / 2.0, size.height / 2.0);
-    env.scene().events().mouseDown(item.get(), midPoint, Events::MouseButtons::left);
-    env.scene().events().mouseMove(item.get(), midPoint);
 }
 
 } // namespace cmd

--- a/lib/src/Commands/DragBegin.h
+++ b/lib/src/Commands/DragBegin.h
@@ -8,18 +8,20 @@
 
 #include "Command.h"
 #include <Spix/Data/ItemPath.h>
+#include <future>
 
 namespace spix {
 namespace cmd {
 
 class DragBegin : public Command {
 public:
-    DragBegin(ItemPath path);
+    DragBegin(ItemPath path, std::promise<void> promise);
 
     void execute(CommandEnvironment& env) override;
 
 private:
     ItemPath m_path;
+    std::promise<void> m_promise;
 };
 
 } // namespace cmd

--- a/lib/src/Commands/DragEnd.cpp
+++ b/lib/src/Commands/DragEnd.cpp
@@ -20,22 +20,22 @@ DragEnd::DragEnd(ItemPath path, std::promise<void> promise)
 
 void DragEnd::execute(CommandEnvironment& env)
 {
-	try {
-		auto item = env.scene().itemAtPath(m_path);
+    try {
+        auto item = env.scene().itemAtPath(m_path);
 
-		if (!item)
+        if (!item)
             throw std::runtime_error("DragEnd: Item not found: " + m_path.string());
 
-		auto size = item->size();
-		Point midPoint(size.width / 2.0, size.height / 2.0);
-		env.scene().events().mouseMove(item.get(), midPoint);
-		env.scene().events().mouseUp(item.get(), midPoint, Events::MouseButtons::left);
+        auto size = item->size();
+        Point midPoint(size.width / 2.0, size.height / 2.0);
+        env.scene().events().mouseMove(item.get(), midPoint);
+        env.scene().events().mouseUp(item.get(), midPoint, Events::MouseButtons::left);
 
-		m_promise.set_value();
-	} catch (const std::runtime_error& e) {
+        m_promise.set_value();
+    } catch (const std::runtime_error& e) {
         env.state().reportError(e.what());
         m_promise.set_exception(std::make_exception_ptr(e));
-	}
+    }
 }
 
 } // namespace cmd

--- a/lib/src/Commands/DragEnd.h
+++ b/lib/src/Commands/DragEnd.h
@@ -8,18 +8,20 @@
 
 #include "Command.h"
 #include <Spix/Data/ItemPath.h>
+#include <future>
 
 namespace spix {
 namespace cmd {
 
 class DragEnd : public Command {
 public:
-    DragEnd(ItemPath path);
+    DragEnd(ItemPath path, std::promise<void> promise);
 
     void execute(CommandEnvironment& env) override;
 
 private:
     ItemPath m_path;
+    std::promise<void> m_promise;
 };
 
 } // namespace cmd

--- a/lib/src/Commands/DropFromExt.cpp
+++ b/lib/src/Commands/DropFromExt.cpp
@@ -22,20 +22,20 @@ DropFromExt::DropFromExt(ItemPath path, PasteboardContent content, std::promise<
 
 void DropFromExt::execute(CommandEnvironment& env)
 {
-	try {
-		auto item = env.scene().itemAtPath(m_path);
+    try {
+        auto item = env.scene().itemAtPath(m_path);
 
-		if (!item)
+        if (!item)
             throw std::runtime_error("DropFromExt: Item not found: " + m_path.string());
 
-		auto size = item->size();
-		Point midPoint(size.width / 2.0, size.height / 2.0);
-		env.scene().events().extMouseDrop(item.get(), midPoint, m_content);
-		m_promise.set_value();
-	} catch (const std::runtime_error& e) {
+        auto size = item->size();
+        Point midPoint(size.width / 2.0, size.height / 2.0);
+        env.scene().events().extMouseDrop(item.get(), midPoint, m_content);
+        m_promise.set_value();
+    } catch (const std::runtime_error& e) {
         env.state().reportError(e.what());
         m_promise.set_exception(std::make_exception_ptr(e));
-	}
+    }
 }
 
 } // namespace cmd

--- a/lib/src/Commands/DropFromExt.cpp
+++ b/lib/src/Commands/DropFromExt.cpp
@@ -8,28 +8,34 @@
 
 #include <CommandExecuter/CommandEnvironment.h>
 #include <Scene/Scene.h>
+#include <stdexcept>
 
 namespace spix {
 namespace cmd {
 
-DropFromExt::DropFromExt(ItemPath path, PasteboardContent content)
+DropFromExt::DropFromExt(ItemPath path, PasteboardContent content, std::promise<void> promise)
 : m_path(std::move(path))
 , m_content(std::move(content))
+, m_promise(std::move(promise))
 {
 }
 
 void DropFromExt::execute(CommandEnvironment& env)
 {
-    auto item = env.scene().itemAtPath(m_path);
+	try {
+		auto item = env.scene().itemAtPath(m_path);
 
-    if (!item) {
-        env.state().reportError("DropFromExt: Item not found: " + m_path.string());
-        return;
-    }
+		if (!item)
+            throw std::runtime_error("DropFromExt: Item not found: " + m_path.string());
 
-    auto size = item->size();
-    Point midPoint(size.width / 2.0, size.height / 2.0);
-    env.scene().events().extMouseDrop(item.get(), midPoint, m_content);
+		auto size = item->size();
+		Point midPoint(size.width / 2.0, size.height / 2.0);
+		env.scene().events().extMouseDrop(item.get(), midPoint, m_content);
+		m_promise.set_value();
+	} catch (const std::runtime_error& e) {
+        env.state().reportError(e.what());
+        m_promise.set_exception(std::make_exception_ptr(e));
+	}
 }
 
 } // namespace cmd

--- a/lib/src/Commands/DropFromExt.h
+++ b/lib/src/Commands/DropFromExt.h
@@ -9,19 +9,21 @@
 #include "Command.h"
 #include <Spix/Data/ItemPath.h>
 #include <Spix/Data/PasteboardContent.h>
+#include <future>
 
 namespace spix {
 namespace cmd {
 
 class DropFromExt : public Command {
 public:
-    DropFromExt(ItemPath path, PasteboardContent content);
+    DropFromExt(ItemPath path, PasteboardContent content, std::promise<void> promise);
 
     void execute(CommandEnvironment& env) override;
 
 private:
     ItemPath m_path;
     PasteboardContent m_content;
+    std::promise<void> m_promise;
 };
 
 } // namespace cmd

--- a/lib/src/Commands/GetProperty.cpp
+++ b/lib/src/Commands/GetProperty.cpp
@@ -7,6 +7,7 @@
 #include "GetProperty.h"
 
 #include <Scene/Scene.h>
+#include <stdexcept>
 
 namespace spix {
 namespace cmd {
@@ -20,14 +21,18 @@ GetProperty::GetProperty(ItemPath path, std::string propertyName, std::promise<s
 
 void GetProperty::execute(CommandEnvironment& env)
 {
-    auto item = env.scene().itemAtPath(m_path);
+    try {
+        auto item = env.scene().itemAtPath(m_path);
 
-    if (item) {
-        auto value = item->stringProperty(m_propertyName);
-        m_promise.set_value(value);
-    } else {
-        m_promise.set_value("");
-        env.state().reportError("InputText: Item not found: " + m_path.string());
+        if (item) {
+            auto value = item->stringProperty(m_propertyName);
+            m_promise.set_value(value);
+        } else {
+            throw std::runtime_error("InputText: Item not found: " + m_path.string());
+        }
+    } catch (const std::runtime_error& e) {
+        env.state().reportError(e.what());
+        m_promise.set_exception(std::make_exception_ptr(e));
     }
 }
 

--- a/lib/src/Commands/InputText.h
+++ b/lib/src/Commands/InputText.h
@@ -8,19 +8,21 @@
 
 #include "Command.h"
 #include <Spix/Data/ItemPath.h>
+#include <future>
 
 namespace spix {
 namespace cmd {
 
 class InputText : public Command {
 public:
-    InputText(ItemPath path, std::string text);
+    InputText(ItemPath path, std::string text, std::promise<void> promise);
 
     void execute(CommandEnvironment& env) override;
 
 private:
     ItemPath m_path;
     std::string m_text;
+	std::promise<void> m_promise;
 };
 
 } // namespace cmd

--- a/lib/src/TestServer.cpp
+++ b/lib/src/TestServer.cpp
@@ -54,27 +54,46 @@ void TestServer::wait(std::chrono::milliseconds waitTime)
 
 void TestServer::mouseClick(ItemPath path)
 {
-    m_cmdExec->enqueueCommand<cmd::ClickOnItem>(path);
+    std::promise<void> promise;
+    auto result = promise.get_future();
+    m_cmdExec->enqueueCommand<cmd::ClickOnItem>(path, std::move(promise));
+
+    result.get();
 }
 
 void TestServer::mouseBeginDrag(ItemPath path)
 {
-    m_cmdExec->enqueueCommand<cmd::DragBegin>(path);
+    std::promise<void> promise;
+    auto result = promise.get_future();
+    m_cmdExec->enqueueCommand<cmd::DragBegin>(path, std::move(promise));
+
+    result.get();
 }
 
 void TestServer::mouseEndDrag(ItemPath path)
 {
-    m_cmdExec->enqueueCommand<cmd::DragEnd>(path);
+    std::promise<void> promise;
+    auto result = promise.get_future();
+    m_cmdExec->enqueueCommand<cmd::DragEnd>(path, std::move(promise));
+
+    result.get();
 }
 
 void TestServer::mouseDropUrls(ItemPath path, const std::vector<std::string>& urls)
 {
-    m_cmdExec->enqueueCommand<cmd::DropFromExt>(path, makePasteboardContentWithUrls(urls));
+    std::promise<void> promise;
+    auto result = promise.get_future();
+    m_cmdExec->enqueueCommand<cmd::DropFromExt>(path, makePasteboardContentWithUrls(urls), std::move(promise));
+
+    result.get();
 }
 
 void TestServer::inputText(ItemPath path, std::string text)
 {
-    m_cmdExec->enqueueCommand<cmd::InputText>(path, std::move(text));
+    std::promise<void> promise;
+    auto result = promise.get_future();
+    m_cmdExec->enqueueCommand<cmd::InputText>(path, std::move(text), std::move(promise));
+    result.get();
 }
 
 std::string TestServer::getStringProperty(ItemPath path, std::string propertyName)

--- a/lib/src/Utils/AnyRpcUtils.h
+++ b/lib/src/Utils/AnyRpcUtils.h
@@ -127,7 +127,13 @@ public:
                 anyrpc::AnyRpcErrorInvalidParams, "Invalid parameters. Number of parameters incorrect.");
         }
 
-        callAndAssignAnyRpcResult<Args...>(m_func, result, std::make_index_sequence<sizeof...(Args)>(), params);
+        try {
+            callAndAssignAnyRpcResult<Args...>(m_func, result, std::make_index_sequence<sizeof...(Args)>(), params);
+        } catch (const anyrpc::AnyRpcException& e) {
+            throw e;
+        } catch (const std::exception& e) {
+            throw anyrpc::AnyRpcException(anyrpc::AnyRpcErrorApplicationError, e.what());
+        }
     }
 
 private:


### PR DESCRIPTION
I don't know how much you'll like this concept...

I'd like to use Spix for automated UI testing, but checking for errors with `getErrors()` after the test is run is a little impractical for me.

What about reporting them over XML-RPC immediately? It results in a nice exception on the Python side.

NOTE: The exception type caught in `execute()` methods must match the thrown type, otherwise `std::make_exception_ptr()` will not work properly.