### PR TITLE
hotfix/vs2019: make project compile in visual studio 2019

### DIFF
--- a/lib/src/Utils/AnyRpcUtils.h
+++ b/lib/src/Utils/AnyRpcUtils.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <anyrpc/anyrpc.h>
+#include <functional>
 
 /**
  * The templates in this file make it easier to register functions with AnyRPC.


### PR DESCRIPTION
Currently, the project doesn't compile when I use visual studio 2019 because it can't see `std::function`

![image](https://user-images.githubusercontent.com/23073817/74939508-ac8ae500-53f8-11ea-9874-418816052d10.png)

