### PR TITLE
Backwards-compatible Qt6 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, ubuntu-18.04, windows-latest, macos-latest, macos-10.15]
+        os: [ubuntu-latest, ubuntu-20.04, windows-latest, macos-latest, macos-10.15]
         build_type: ['Release', 'Debug']
         shared_libs: ['ON', 'OFF']
         include:
@@ -22,9 +22,6 @@ jobs:
             triplet: 'x64-linux'
             cmake_flags: '-DCMAKE_CXX_COMPILER=clang++'
           - os: ubuntu-20.04
-            triplet: 'x64-linux'
-            cmake_flags: '-DCMAKE_CXX_COMPILER=g++'
-          - os: ubuntu-18.04
             triplet: 'x64-linux'
             cmake_flags: '-DCMAKE_CXX_COMPILER=g++'
           - os: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,9 @@ jobs:
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
+        with:
+          aqtversion: '>=1.2.1'
+          version: 6.1.0
 
       - name: Install dependencies
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-20.04, windows-latest, macos-latest, macos-10.15]
         build_type: ['Release', 'Debug']
         shared_libs: ['ON', 'OFF']
+        qt_version: [[5, 12, 12], [5, 15, 2], [6, 2, 3]]
         include:
           - os: ubuntu-latest
             triplet: 'x64-linux'
@@ -41,11 +42,19 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
 
+      - name: Cache Qt
+        id: cache-qt
+        uses: actions/cache@v1  # not v2!
+        with:
+          path: ../Qt
+          key: ${{ runner.os }}-${{ join(matrix.qt_version, '.') }}-QtCache
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
           aqtversion: '>=1.2.1'
-          version: 6.1.0
+          version: ${{ join(matrix.qt_version, '.') }}
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
       - name: Install dependencies
         env:
@@ -56,7 +65,7 @@ jobs:
       - name: "Configure"
         run: |
           mkdir build
-          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DSPIX_BUILD_TESTS=ON -DSPIX_BUILD_EXAMPLES=ON ${{ matrix.cmake_flags}} -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} .
+          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DSPIX_BUILD_TESTS=ON -DSPIX_BUILD_EXAMPLES=ON ${{ matrix.cmake_flags}} -DBUILD_SHARED_LIBS=${{ matrix.shared_libs }} -DSPIX_QT_MAJOR=${{ matrix.qt_version[0] }} .
       
       - name: "Print cmake compile commands"
         if: ${{ !contains(matrix.os, 'windows') }}
@@ -67,6 +76,19 @@ jobs:
       
       - name: "Run Tests"
         run: cd build && ctest -VV -C ${{ matrix.build_type }} && cd ..
+      
+      - name: "Test GTest Examples (*nix)"
+        # Qt6 on GitHub Actions MacOS is currently bugged: https://bugreports.qt.io/browse/QTIFW-1592
+        if: ${{ !contains(matrix.os, 'windows') && !(contains(matrix.os, 'mac') && matrix.qt_version[0] == 6) }}
+        run: |
+          build/examples/GTest/SpixGTestExample -platform minimal
+          build/examples/RepeaterLoader/SpixRepeaterLoaderExampleGTest -platform minimal
+
+      - name: "Test GTest Examples (win)"
+        if: ${{ contains(matrix.os, 'windows') }}
+        run: |
+          .\build\examples\GTest\${{ matrix.build_type }}\SpixGTestExample.exe -platform minimal
+          .\build\examples\RepeaterLoader\${{ matrix.build_type }}\SpixRepeaterLoaderExampleGTest.exe -platform minimal
       
       - name: "Install Spix (*nix)"
         if: ${{ !contains(matrix.os, 'windows') }}
@@ -80,7 +102,7 @@ jobs:
         run: |
           cd examples/BasicStandalone
           mkdir build
-          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_flags}} .
+          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DSPIX_QT_MAJOR=${{ matrix.qt_version[0] }} ${{ matrix.cmake_flags}} .
           cmake --build build --config ${{ matrix.build_type }}
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.18)
 project(Spix LANGUAGES CXX)
 
 option(SPIX_BUILD_EXAMPLES "Build Spix examples." ON)
 option(SPIX_BUILD_TESTS "Build Spix unit tests." OFF)
+set(SPIX_QT_MAJOR "6" CACHE STRING "Major Qt version to build Spix against")
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 set(CMAKE_CXX_STANDARD 14)
 
 # Hide symbols unless explicitly flagged with SPIX_EXPORT

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -6,7 +6,7 @@ mkdir deps && cd deps
 git clone --recursive https://github.com/sgieseking/anyrpc.git
 cd anyrpc && mkdir build && cd build
 if [[ $RUNNER_OS == "Windows" ]]; then
-    cmake -G"Visual Studio 16 2019" -DCMAKE_BUILD_TYPE=$CI_BUILD_TYPE -DBUILD_EXAMPLES=OFF -DBUILD_WITH_LOG4CPLUS=OFF -DANYRPC_LIB_BUILD_SHARED=${SHARED_LIBS} ..
+    cmake -G"Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=$CI_BUILD_TYPE -DBUILD_EXAMPLES=OFF -DBUILD_WITH_LOG4CPLUS=OFF -DANYRPC_LIB_BUILD_SHARED=${SHARED_LIBS} ..
     cmake --build . --target install --config $CI_BUILD_TYPE
 else
     cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=$CI_BUILD_TYPE -DBUILD_EXAMPLES=OFF -DBUILD_WITH_LOG4CPLUS=OFF -DANYRPC_LIB_BUILD_SHARED=${SHARED_LIBS} ..
@@ -18,7 +18,7 @@ cd ../..
 git clone --recursive https://github.com/google/googletest.git
 cd googletest && mkdir build && cd build
 if [[ $RUNNER_OS == "Windows" ]]; then
-    cmake -G"Visual Studio 16 2019" -Dgtest_force_shared_crt=ON -DCMAKE_BUILD_TYPE=$CI_BUILD_TYPE ..
+    cmake -G"Visual Studio 17 2022" -Dgtest_force_shared_crt=ON -DCMAKE_BUILD_TYPE=$CI_BUILD_TYPE ..
     cmake --build . --target install --config $CI_BUILD_TYPE
 else
     cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=$CI_BUILD_TYPE ..

--- a/examples/Basic/CMakeLists.txt
+++ b/examples/Basic/CMakeLists.txt
@@ -4,8 +4,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 COMPONENTS Core Quick REQUIRED)
+find_package(Qt6 COMPONENTS Core Quick REQUIRED)
 
 add_executable(SpixBasicExample "main.cpp" "qml.qrc")
 target_compile_definitions(SpixBasicExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixBasicExample PRIVATE Qt5::Core Qt5::Quick Spix)
+target_link_libraries(SpixBasicExample PRIVATE Qt6::Core Qt6::Quick Spix)

--- a/examples/Basic/CMakeLists.txt
+++ b/examples/Basic/CMakeLists.txt
@@ -4,8 +4,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 COMPONENTS Core Quick REQUIRED)
+find_package(Qt${SPIX_QT_MAJOR} COMPONENTS Core Quick REQUIRED)
 
 add_executable(SpixBasicExample "main.cpp" "qml.qrc")
 target_compile_definitions(SpixBasicExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixBasicExample PRIVATE Qt6::Core Qt6::Quick Spix)
+target_link_libraries(SpixBasicExample PRIVATE Qt${SPIX_QT_MAJOR}::Core Qt${SPIX_QT_MAJOR}::Quick Spix)

--- a/examples/BasicStandalone/CMakeLists.txt
+++ b/examples/BasicStandalone/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 project(SpixStandaloneExample LANGUAGES CXX)
 
+set(SPIX_QT_MAJOR "6" CACHE STRING "Major Qt version to build Spix against")
+
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake/modules")
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -14,9 +16,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 #
 find_package(Threads REQUIRED)
 find_package(AnyRPC REQUIRED)
-find_package(Qt5 COMPONENTS Core Quick REQUIRED)
+find_package(Qt${SPIX_QT_MAJOR} COMPONENTS Core Quick REQUIRED)
 find_package(Spix CONFIG REQUIRED)
 
 add_executable(SpixStandaloneExample "main.cpp" "qml.qrc")
 target_compile_definitions(SpixStandaloneExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixStandaloneExample PRIVATE Threads::Threads Qt5::Core Qt5::Quick Spix::Spix)
+target_link_libraries(SpixStandaloneExample PRIVATE Threads::Threads Qt${SPIX_QT_MAJOR}::Core Qt${SPIX_QT_MAJOR}::Quick Spix::Spix)

--- a/examples/GTest/CMakeLists.txt
+++ b/examples/GTest/CMakeLists.txt
@@ -4,9 +4,11 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 COMPONENTS Core Quick REQUIRED)
+set(SPIX_QT_MAJOR "6" CACHE STRING "Major Qt version to build Spix against")
+
+find_package(Qt${SPIX_QT_MAJOR} COMPONENTS Core Quick REQUIRED)
 find_package(GTest REQUIRED)
 
 add_executable(SpixGTestExample "main.cpp" "qml.qrc")
 target_compile_definitions(SpixGTestExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixGTestExample PRIVATE Qt6::Core Qt6::Quick GTest::GTest Spix)
+target_link_libraries(SpixGTestExample PRIVATE Qt${SPIX_QT_MAJOR}::Core Qt${SPIX_QT_MAJOR}::Quick GTest::GTest Spix)

--- a/examples/GTest/CMakeLists.txt
+++ b/examples/GTest/CMakeLists.txt
@@ -4,9 +4,9 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 COMPONENTS Core Quick REQUIRED)
+find_package(Qt6 COMPONENTS Core Quick REQUIRED)
 find_package(GTest REQUIRED)
 
 add_executable(SpixGTestExample "main.cpp" "qml.qrc")
 target_compile_definitions(SpixGTestExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixGTestExample PRIVATE Qt5::Core Qt5::Quick GTest::GTest Spix)
+target_link_libraries(SpixGTestExample PRIVATE Qt6::Core Qt6::Quick GTest::GTest Spix)

--- a/examples/ListGridView/CMakeLists.txt
+++ b/examples/ListGridView/CMakeLists.txt
@@ -4,8 +4,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 COMPONENTS Core Quick REQUIRED)
+find_package(Qt6 COMPONENTS Core Quick REQUIRED)
 
 add_executable(SpixListGridViewExample "main.cpp" "qml.qrc")
 target_compile_definitions(SpixListGridViewExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixListGridViewExample PRIVATE Qt5::Core Qt5::Quick Spix)
+target_link_libraries(SpixListGridViewExample PRIVATE Qt6::Core Qt6::Quick Spix)

--- a/examples/ListGridView/CMakeLists.txt
+++ b/examples/ListGridView/CMakeLists.txt
@@ -4,8 +4,10 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 COMPONENTS Core Quick REQUIRED)
+set(SPIX_QT_MAJOR "6" CACHE STRING "Major Qt version to build Spix against")
+
+find_package(Qt${SPIX_QT_MAJOR} COMPONENTS Core Quick REQUIRED)
 
 add_executable(SpixListGridViewExample "main.cpp" "qml.qrc")
 target_compile_definitions(SpixListGridViewExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixListGridViewExample PRIVATE Qt6::Core Qt6::Quick Spix)
+target_link_libraries(SpixListGridViewExample PRIVATE Qt${SPIX_QT_MAJOR}::Core Qt${SPIX_QT_MAJOR}::Quick Spix)

--- a/examples/RemoteCtrl/CMakeLists.txt
+++ b/examples/RemoteCtrl/CMakeLists.txt
@@ -4,8 +4,10 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 COMPONENTS Core Quick REQUIRED)
+set(SPIX_QT_MAJOR "6" CACHE STRING "Major Qt version to build Spix against")
+
+find_package(Qt${SPIX_QT_MAJOR} COMPONENTS Core Quick REQUIRED)
 
 add_executable(SpixRemoteCtrlExample "main.cpp" "qml.qrc")
 target_compile_definitions(SpixRemoteCtrlExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixRemoteCtrlExample PRIVATE Qt6::Core Qt6::Quick Spix)
+target_link_libraries(SpixRemoteCtrlExample PRIVATE Qt${SPIX_QT_MAJOR}::Core Qt${SPIX_QT_MAJOR}::Quick Spix)

--- a/examples/RemoteCtrl/CMakeLists.txt
+++ b/examples/RemoteCtrl/CMakeLists.txt
@@ -4,8 +4,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 COMPONENTS Core Quick REQUIRED)
+find_package(Qt6 COMPONENTS Core Quick REQUIRED)
 
 add_executable(SpixRemoteCtrlExample "main.cpp" "qml.qrc")
 target_compile_definitions(SpixRemoteCtrlExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixRemoteCtrlExample PRIVATE Qt5::Core Qt5::Quick Spix)
+target_link_libraries(SpixRemoteCtrlExample PRIVATE Qt6::Core Qt6::Quick Spix)

--- a/examples/RepeaterLoader/CMakeLists.txt
+++ b/examples/RepeaterLoader/CMakeLists.txt
@@ -4,8 +4,14 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 COMPONENTS Core Quick REQUIRED)
+set(SPIX_QT_MAJOR "6" CACHE STRING "Major Qt version to build Spix against")
+
+find_package(Qt${SPIX_QT_MAJOR} COMPONENTS Core Quick REQUIRED)
+find_package(GTest REQUIRED)
 
 add_executable(SpixRepeaterLoaderExample "main.cpp" "qml.qrc")
+add_executable(SpixRepeaterLoaderExampleGTest "main_gtest.cpp" "qml.qrc")
 target_compile_definitions(SpixRepeaterLoaderExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixRepeaterLoaderExample PRIVATE Qt6::Core Qt6::Quick Spix)
+target_compile_definitions(SpixRepeaterLoaderExampleGTest PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
+target_link_libraries(SpixRepeaterLoaderExample PRIVATE Qt${SPIX_QT_MAJOR}::Core Qt${SPIX_QT_MAJOR}::Quick Spix)
+target_link_libraries(SpixRepeaterLoaderExampleGTest PRIVATE Qt${SPIX_QT_MAJOR}::Core Qt${SPIX_QT_MAJOR}::Quick GTest::GTest Spix)

--- a/examples/RepeaterLoader/CMakeLists.txt
+++ b/examples/RepeaterLoader/CMakeLists.txt
@@ -4,8 +4,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt5 COMPONENTS Core Quick REQUIRED)
+find_package(Qt6 COMPONENTS Core Quick REQUIRED)
 
 add_executable(SpixRepeaterLoaderExample "main.cpp" "qml.qrc")
 target_compile_definitions(SpixRepeaterLoaderExample PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
-target_link_libraries(SpixRepeaterLoaderExample PRIVATE Qt5::Core Qt5::Quick Spix)
+target_link_libraries(SpixRepeaterLoaderExample PRIVATE Qt6::Core Qt6::Quick Spix)

--- a/examples/RepeaterLoader/main_gtest.cpp
+++ b/examples/RepeaterLoader/main_gtest.cpp
@@ -1,0 +1,108 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+
+#include <Spix/Events/Identifiers.h>
+#include <Spix/QtQmlBot.h>
+
+#include <atomic>
+#include <gtest/gtest.h>
+#include <iostream>
+
+class SpixGTest;
+static SpixGTest* srv;
+
+class SpixGTest : public spix::TestServer {
+public:
+    SpixGTest(int argc, char* argv[])
+    {
+        m_argc = argc;
+        m_argv = argv;
+    }
+
+    int testResult() { return m_result.load(); }
+
+protected:
+    int m_argc;
+    char** m_argv;
+    std::atomic<int> m_result {0};
+
+    void executeTest() override
+    {
+        srv = this;
+        ::testing::InitGoogleTest(&m_argc, m_argv);
+        auto testResult = RUN_ALL_TESTS();
+        m_result.store(testResult);
+    }
+};
+
+TEST(RepeaterLoaderGTest, RepeaterLoaderTest)
+{
+    EXPECT_FALSE(srv->existsAndVisible("mainWindow/ItemDisplayLoader/textItem"))
+        << "Error: Item should not be visible at launch.";
+
+    srv->mouseClick("mainWindow/ItemButtons/Item_0");
+    srv->wait(std::chrono::milliseconds(500));
+
+    EXPECT_TRUE(srv->existsAndVisible("mainWindow/ItemDisplayLoader/textItem"))
+        << "Error: Item should be displayed after button pressed.";
+
+    // 'ItemButtons' is not required in the path,
+    // as 'gridItem_0' is unique within 'mainWindow'
+    srv->mouseClick("mainWindow/Item_1");
+    srv->wait(std::chrono::milliseconds(500));
+
+    EXPECT_STREQ(srv->getStringProperty("mainWindow/ItemDisplayLoader/textItem", "text").c_str(),
+        "I am a view with a pear. Trust me.")
+        << "Error: Wrong item displayed.";
+
+    srv->mouseClick("mainWindow/ItemButtons/Item_2");
+    srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick("mainWindow/ItemButtons/Item_0");
+    srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick("mainWindow/ItemButtons/Item_3");
+    srv->wait(std::chrono::milliseconds(100));
+
+    EXPECT_STREQ(srv->getStringProperty("mainWindow/ItemDisplayLoader/textItem", "text").c_str(),
+        "I am a view with a cucumber. Trust me.")
+        << "Error: Wrong item displayed";
+
+    srv->mouseClick("mainWindow/itemCombo");
+    srv->wait(std::chrono::milliseconds(400));
+
+    srv->enterKey("mainWindow/itemCombo", spix::KeyCodes::Down, 0); // Down
+    srv->wait(std::chrono::milliseconds(200));
+    srv->enterKey("mainWindow/itemCombo", spix::KeyCodes::Down, 0); // Down
+    srv->wait(std::chrono::milliseconds(200));
+    srv->enterKey("mainWindow/itemCombo", spix::KeyCodes::Enter, 0); // Enter
+    srv->wait(std::chrono::milliseconds(100));
+
+    EXPECT_STREQ(srv->getStringProperty("mainWindow/ItemDisplayLoader/textItem", "text").c_str(),
+        "I am a view with a banana. Trust me.")
+        << "Error: Wrong item displayed";
+
+    srv->quit();
+}
+
+int main(int argc, char* argv[])
+{
+    // Init Qt Qml Application
+    QGuiApplication app(argc, argv);
+    QQmlApplicationEngine engine;
+    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
+    if (engine.rootObjects().isEmpty())
+        return -1;
+
+    // Instantiate and run tests
+    SpixGTest tests(argc, argv);
+    auto bot = new spix::QtQmlBot();
+    bot->runTestServer(tests);
+
+    app.exec();
+    return tests.testResult();
+}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,14 +8,14 @@ include(CMakePackageConfigHelpers)
 # Dependencies
 #
 find_package(Threads REQUIRED)
-find_package(Qt6
+find_package(AnyRPC REQUIRED)
+find_package(Qt${SPIX_QT_MAJOR}
     COMPONENTS
         Core
         Gui
         Quick
     REQUIRED)
-find_package(AnyRPC REQUIRED)
-
+message("Building Spix for Qt ${SPIX_QT_MAJOR}")
 
 #
 # Sources
@@ -106,7 +106,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX source FILES ${SOURCES})
 #
 # Qt MOC Files
 #
-qt6_wrap_cpp(MOC_FILES "include/Spix/QtQmlBot.h")
+cmake_language(CALL "qt${SPIX_QT_MAJOR}_wrap_cpp" MOC_FILES "include/Spix/QtQmlBot.h")
 
 
 #
@@ -124,9 +124,9 @@ target_include_directories(Spix
 target_link_libraries(Spix
     PUBLIC
         Threads::Threads
-        Qt6::Core
-        Qt6::Gui
-        Qt6::Quick
+        Qt${SPIX_QT_MAJOR}::Core
+        Qt${SPIX_QT_MAJOR}::Gui
+        Qt${SPIX_QT_MAJOR}::Quick
         AnyRPC::anyrpc
 )
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,7 +8,7 @@ include(CMakePackageConfigHelpers)
 # Dependencies
 #
 find_package(Threads REQUIRED)
-find_package(Qt5
+find_package(Qt6
     COMPONENTS
         Core
         Gui
@@ -106,7 +106,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX source FILES ${SOURCES})
 #
 # Qt MOC Files
 #
-qt5_wrap_cpp(MOC_FILES "include/Spix/QtQmlBot.h")
+qt6_wrap_cpp(MOC_FILES "include/Spix/QtQmlBot.h")
 
 
 #
@@ -124,9 +124,9 @@ target_include_directories(Spix
 target_link_libraries(Spix
     PUBLIC
         Threads::Threads
-        Qt5::Core
-        Qt5::Gui
-        Qt5::Quick
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Quick
         AnyRPC::anyrpc
 )
 

--- a/lib/src/Scene/Qt/QtEvents.cpp
+++ b/lib/src/Scene/Qt/QtEvents.cpp
@@ -114,9 +114,17 @@ void QtEvents::mouseUp(Item* item, Point loc, MouseButton button)
     if (!window)
         return;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+    // Qt6 expects the mouse to be down during the event
     Qt::MouseButton eventCausingButton = getQtMouseButtonValue(button);
     Qt::MouseButtons activeButtons = getQtMouseButtonValue(m_pressedMouseButtons);
     m_pressedMouseButtons ^= button;
+#else
+    // Qt5 expects the mouse to be up during the event
+    m_pressedMouseButtons ^= button;
+    Qt::MouseButton eventCausingButton = getQtMouseButtonValue(button);
+    Qt::MouseButtons activeButtons = getQtMouseButtonValue(m_pressedMouseButtons);
+#endif
 
     QMouseEvent* event
         = new QMouseEvent(QEvent::MouseButtonRelease, windowLoc, eventCausingButton, activeButtons, Qt::NoModifier);

--- a/lib/src/Scene/Qt/QtEvents.cpp
+++ b/lib/src/Scene/Qt/QtEvents.cpp
@@ -102,7 +102,8 @@ void QtEvents::mouseDown(Item* item, Point loc, MouseButton button)
     Qt::MouseButton eventCausingButton = getQtMouseButtonValue(button);
     Qt::MouseButtons activeButtons = getQtMouseButtonValue(m_pressedMouseButtons);
 
-    QMouseEvent* event = new QMouseEvent(QEvent::MouseButtonPress, windowLoc, eventCausingButton, activeButtons, Qt::NoModifier);
+    QMouseEvent* event
+        = new QMouseEvent(QEvent::MouseButtonPress, windowLoc, eventCausingButton, activeButtons, Qt::NoModifier);
     QGuiApplication::postEvent(window, event);
 }
 
@@ -117,7 +118,8 @@ void QtEvents::mouseUp(Item* item, Point loc, MouseButton button)
     Qt::MouseButtons activeButtons = getQtMouseButtonValue(m_pressedMouseButtons);
     m_pressedMouseButtons ^= button;
 
-    QMouseEvent* event = new QMouseEvent(QEvent::MouseButtonRelease, windowLoc, eventCausingButton, activeButtons, Qt::NoModifier);
+    QMouseEvent* event
+        = new QMouseEvent(QEvent::MouseButtonRelease, windowLoc, eventCausingButton, activeButtons, Qt::NoModifier);
     QGuiApplication::postEvent(window, event);
 }
 
@@ -138,7 +140,8 @@ void QtEvents::mouseMove(Item* item, Point loc)
 
     // Wiggle the cursor a bit. This is needed to correctly recognize drag events
     windowLoc.rx() += 1;
-    mouseMoveEvent = new QMouseEvent(QEvent::MouseMove, windowLoc, Qt::MouseButton::NoButton, activeButtons, Qt::NoModifier);
+    mouseMoveEvent
+        = new QMouseEvent(QEvent::MouseMove, windowLoc, Qt::MouseButton::NoButton, activeButtons, Qt::NoModifier);
     QGuiApplication::postEvent(window, mouseMoveEvent);
 }
 
@@ -150,8 +153,7 @@ void QtEvents::stringInput(Item* item, const std::string& text)
 
     auto window = qtitem->qquickitem()->window();
 
-    auto keyDownEvent
-        = new QKeyEvent(QEvent::KeyPress, 0 /* key id */, Qt::NoModifier, QString::fromStdString(text));
+    auto keyDownEvent = new QKeyEvent(QEvent::KeyPress, 0 /* key id */, Qt::NoModifier, QString::fromStdString(text));
     QGuiApplication::postEvent(window, keyDownEvent);
 }
 
@@ -185,16 +187,16 @@ void QtEvents::extMouseDrop(Item* item, Point loc, PasteboardContent& content)
     }
     mimeData->setUrls(urlList);
 
-    auto enter = new QDragEnterEvent(
-        windowLocInt, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData, Qt::MouseButton::NoButton, Qt::NoModifier);
+    auto enter = new QDragEnterEvent(windowLocInt, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData,
+        Qt::MouseButton::NoButton, Qt::NoModifier);
     QGuiApplication::postEvent(window, enter);
 
-    auto move = new QDragMoveEvent(
-        windowLocInt, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData, Qt::MouseButton::NoButton, Qt::NoModifier);
+    auto move = new QDragMoveEvent(windowLocInt, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData,
+        Qt::MouseButton::NoButton, Qt::NoModifier);
     QGuiApplication::postEvent(window, move);
 
-    auto drop = new QDropEvent(
-        windowLoc, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData, Qt::MouseButton::NoButton, Qt::NoModifier);
+    auto drop = new QDropEvent(windowLoc, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData,
+        Qt::MouseButton::NoButton, Qt::NoModifier);
     QGuiApplication::postEvent(window, drop);
 }
 

--- a/lib/src/Scene/Qt/QtEvents.cpp
+++ b/lib/src/Scene/Qt/QtEvents.cpp
@@ -102,8 +102,7 @@ void QtEvents::mouseDown(Item* item, Point loc, MouseButton button)
     Qt::MouseButton eventCausingButton = getQtMouseButtonValue(button);
     Qt::MouseButtons activeButtons = getQtMouseButtonValue(m_pressedMouseButtons);
 
-    QMouseEvent* event = new QMouseEvent(
-        QEvent::MouseButtonPress, windowLoc, eventCausingButton, activeButtons, Qt::KeyboardModifier());
+    QMouseEvent* event = new QMouseEvent(QEvent::MouseButtonPress, windowLoc, eventCausingButton, activeButtons, Qt::NoModifier);
     QGuiApplication::postEvent(window, event);
 }
 
@@ -114,12 +113,11 @@ void QtEvents::mouseUp(Item* item, Point loc, MouseButton button)
     if (!window)
         return;
 
-    m_pressedMouseButtons ^= button;
     Qt::MouseButton eventCausingButton = getQtMouseButtonValue(button);
     Qt::MouseButtons activeButtons = getQtMouseButtonValue(m_pressedMouseButtons);
+    m_pressedMouseButtons ^= button;
 
-    QMouseEvent* event = new QMouseEvent(
-        QEvent::MouseButtonRelease, windowLoc, eventCausingButton, activeButtons, Qt::KeyboardModifier());
+    QMouseEvent* event = new QMouseEvent(QEvent::MouseButtonRelease, windowLoc, eventCausingButton, activeButtons, Qt::NoModifier);
     QGuiApplication::postEvent(window, event);
 }
 
@@ -134,14 +132,13 @@ void QtEvents::mouseMove(Item* item, Point loc)
 
     // Wiggle the cursor a bit. This is needed to correctly recognize drag events
     windowLoc.rx() -= 1;
-    QMouseEvent* mouseMoveEvent = new QMouseEvent(
-        QEvent::MouseMove, windowLoc, Qt::MouseButton::NoButton, activeButtons, Qt::KeyboardModifier());
+    QMouseEvent* mouseMoveEvent
+        = new QMouseEvent(QEvent::MouseMove, windowLoc, Qt::MouseButton::NoButton, activeButtons, Qt::NoModifier);
     QGuiApplication::postEvent(window, mouseMoveEvent);
 
     // Wiggle the cursor a bit. This is needed to correctly recognize drag events
     windowLoc.rx() += 1;
-    mouseMoveEvent = new QMouseEvent(
-        QEvent::MouseMove, windowLoc, Qt::MouseButton::NoButton, activeButtons, Qt::KeyboardModifier());
+    mouseMoveEvent = new QMouseEvent(QEvent::MouseMove, windowLoc, Qt::MouseButton::NoButton, activeButtons, Qt::NoModifier);
     QGuiApplication::postEvent(window, mouseMoveEvent);
 }
 
@@ -154,7 +151,7 @@ void QtEvents::stringInput(Item* item, const std::string& text)
     auto window = qtitem->qquickitem()->window();
 
     auto keyDownEvent
-        = new QKeyEvent(QEvent::KeyPress, 0 /* key id */, Qt::KeyboardModifier(), QString::fromStdString(text));
+        = new QKeyEvent(QEvent::KeyPress, 0 /* key id */, Qt::NoModifier, QString::fromStdString(text));
     QGuiApplication::postEvent(window, keyDownEvent);
 }
 
@@ -188,16 +185,16 @@ void QtEvents::extMouseDrop(Item* item, Point loc, PasteboardContent& content)
     }
     mimeData->setUrls(urlList);
 
-    auto enter = new QDragEnterEvent(windowLocInt, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData,
-        Qt::MouseButton::NoButton, Qt::KeyboardModifier());
+    auto enter = new QDragEnterEvent(
+        windowLocInt, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData, Qt::MouseButton::NoButton, Qt::NoModifier);
     QGuiApplication::postEvent(window, enter);
 
-    auto move = new QDragMoveEvent(windowLocInt, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData,
-        Qt::MouseButton::NoButton, Qt::KeyboardModifier());
+    auto move = new QDragMoveEvent(
+        windowLocInt, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData, Qt::MouseButton::NoButton, Qt::NoModifier);
     QGuiApplication::postEvent(window, move);
 
-    auto drop = new QDropEvent(windowLoc, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData,
-        Qt::MouseButton::NoButton, Qt::KeyboardModifier());
+    auto drop = new QDropEvent(
+        windowLoc, Qt::CopyAction | Qt::MoveAction | Qt::LinkAction, mimeData, Qt::MouseButton::NoButton, Qt::NoModifier);
     QGuiApplication::postEvent(window, drop);
 }
 


### PR DESCRIPTION
This PR aims to finish the work started by @faaxm in #29: it contains the same changes plus reworking of the CMake files to allow for Qt5 and Qt6 support (I didn't attempt to add support for optional libraries). The reworks are as follows:
* Added a `SPIX_QT_MAJOR` cache variable which controls which major Qt version Spix builds against (right now it defaults to Qt6). Updated all CMake files to use this variable.
* Bumped minimum CMake to 3.18 to support [`cmake_language`](https://cmake.org/cmake/help/latest/command/cmake_language.html). This change could be reverted if needed, but the alternative is a bit hacky.
* Updated CI to test Qt5.12, Qt5.15 and Qt6.2.
* Added some other stuff to the README

@faaxm let me know if you would like me to make any changes (or feel free to push changes yourself).