### PR TITLE
Screenshot warning

### DIFF
--- a/lib/include/Spix/TestServer.h
+++ b/lib/include/Spix/TestServer.h
@@ -61,7 +61,7 @@ public:
     bool existsAndVisible(ItemPath path);
     std::vector<std::string> getErrors();
 
-    void takeScreenshot(ItemPath targetItem, std::string filePath);
+    bool takeScreenshot(ItemPath targetItem, std::string filePath);
     void quit();
 
 protected:

--- a/lib/src/AnyRpcServer.cpp
+++ b/lib/src/AnyRpcServer.cpp
@@ -86,7 +86,7 @@ AnyRpcServer::AnyRpcServer(int anyrpcPort)
         "Returns internal errors that occurred during test execution | getErrors() : (strings) [error1, ...]",
         [this]() { return getErrors(); });
 
-    utils::AddFunctionToAnyRpc<void(std::string, std::string)>(methodManager, "takeScreenshot",
+    utils::AddFunctionToAnyRpc<bool(std::string, std::string)>(methodManager, "takeScreenshot",
         "Take a screenshot of the object and save it as a file | takeScreenshot(string pathToTargetedItem, string "
         "filePath)",
         [this](std::string targetItem, std::string filePath) {

--- a/lib/src/Commands/Screenshot.h
+++ b/lib/src/Commands/Screenshot.h
@@ -9,18 +9,21 @@
 #include "Command.h"
 #include <Spix/Data/ItemPath.h>
 
+#include <future>
+
 namespace spix {
 namespace cmd {
 
 class Screenshot : public Command {
 public:
-    Screenshot(ItemPath targetItemPath, std::string filePath);
+    Screenshot(ItemPath targetItemPath, std::string filePath, std::promise<bool> promise);
 
     void execute(CommandEnvironment& env) override;
 
 private:
     ItemPath m_itemPath;
     std::string m_filePath;
+    std::promise<bool> m_promise;
 };
 
 } // namespace cmd

--- a/lib/src/Scene/Mock/MockScene.cpp
+++ b/lib/src/Scene/Mock/MockScene.cpp
@@ -24,8 +24,9 @@ Events& MockScene::events()
     return m_events;
 }
 
-void MockScene::takeScreenshot(const ItemPath&, const std::string&)
+bool MockScene::takeScreenshot(Item&, const std::string&)
 {
+    return true;
 }
 
 void MockScene::addItemAtPath(MockItem item, const ItemPath& path)

--- a/lib/src/Scene/Mock/MockScene.h
+++ b/lib/src/Scene/Mock/MockScene.h
@@ -24,7 +24,7 @@ public:
     Events& events() override;
 
     // Tasks
-    void takeScreenshot(const ItemPath& targetItem, const std::string& filePath) override;
+    bool takeScreenshot(Item& targetItem, const std::string& filePath) override;
 
     // Mock stuff
     void addItemAtPath(MockItem item, const ItemPath& path);

--- a/lib/src/Scene/Qt/QtScene.cpp
+++ b/lib/src/Scene/Qt/QtScene.cpp
@@ -108,12 +108,9 @@ Events& QtScene::events()
     return m_events;
 }
 
-void QtScene::takeScreenshot(const ItemPath& targetItem, const std::string& filePath)
+bool QtScene::takeScreenshot(Item& targetItem, const std::string& filePath)
 {
-    auto item = getQQuickItemAtPath(targetItem);
-    if (!item) {
-        return;
-    }
+    auto item = dynamic_cast<QtItem&>(targetItem).qquickitem();
 
     // take screenshot of the full window
     auto windowImage = item->window()->grabWindow();
@@ -127,7 +124,7 @@ void QtScene::takeScreenshot(const ItemPath& targetItem, const std::string& file
 
     // crop the window image to the item rect
     auto image = windowImage.copy(imageCropRect);
-    image.save(QString::fromStdString(filePath));
+    return image.save(QString::fromStdString(filePath));
 }
 
 } // namespace spix

--- a/lib/src/Scene/Qt/QtScene.h
+++ b/lib/src/Scene/Qt/QtScene.h
@@ -27,7 +27,7 @@ public:
     Events& events() override;
 
     // Tasks
-    void takeScreenshot(const ItemPath& targetItem, const std::string& filePath) override;
+    bool takeScreenshot(Item& targetItem, const std::string& filePath) override;
 
 private:
     QtEvents m_events;

--- a/lib/src/Scene/Scene.h
+++ b/lib/src/Scene/Scene.h
@@ -36,7 +36,7 @@ public:
     virtual Events& events() = 0;
 
     // Tasks
-    virtual void takeScreenshot(const ItemPath& targetItem, const std::string& filePath) = 0;
+    virtual bool takeScreenshot(Item& targetItem, const std::string& filePath) = 0;
 };
 
 } // namespace spix

--- a/lib/src/TestServer.cpp
+++ b/lib/src/TestServer.cpp
@@ -149,9 +149,13 @@ std::vector<std::string> TestServer::getErrors()
     return result.get();
 }
 
-void TestServer::takeScreenshot(ItemPath targetItem, std::string filePath)
+bool TestServer::takeScreenshot(ItemPath targetItem, std::string filePath)
 {
-    m_cmdExec->enqueueCommand<cmd::Screenshot>(targetItem, std::move(filePath));
+    std::promise<bool> promise;
+    auto result = promise.get_future();
+    m_cmdExec->enqueueCommand<cmd::Screenshot>(targetItem, std::move(filePath), std::move(promise));
+
+    return result.get();
 }
 
 void TestServer::quit()


### PR DESCRIPTION
This PR aims to help the client know if `takeScreenshot` method has managed to produce **and** save an image by returning a boolean value through xmlrpc and adding some logs.
The need of such logs appeared to me in the case you don't specify an image format, for example if you type `s.takeScreenshot("mainWindow","image")` no image will be produce because Qt doesn't recognize a valid file extension (because the optional parameter `const char *format = nullptr` of `QImage::save` isn't set) and the client currently hasn't a clue of why it didn't work.
However, I'm not quite sure if I've done it right, following your conventions, so please tell me if anything has been done wrong.