### PR TITLE
DRAFT: Add new searchItem method 

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -62,6 +62,8 @@ set(SOURCES
     src/Commands/SetProperty.h
     src/Commands/Wait.cpp
     src/Commands/Wait.h
+    src/Commands/SearchItem.cpp
+    src/Commands/SearchItem.h
 
     src/CommandExecuter/CommandEnvironment.cpp
     src/CommandExecuter/CommandEnvironment.h

--- a/lib/include/Spix/TestServer.h
+++ b/lib/include/Spix/TestServer.h
@@ -61,6 +61,8 @@ public:
     bool existsAndVisible(ItemPath path);
     std::vector<std::string> getErrors();
 
+    std::vector<std::string> searchItem(ItemPath path);
+
     void takeScreenshot(ItemPath targetItem, std::string filePath);
     void quit();
 

--- a/lib/src/AnyRpcServer.cpp
+++ b/lib/src/AnyRpcServer.cpp
@@ -99,6 +99,10 @@ AnyRpcServer::AnyRpcServer(int anyrpcPort)
         "Executes a generic command | command(string command, string payload)",
         [this](std::string command, std::string payload) { genericCommand(command, payload); });
 
+    utils::AddFunctionToAnyRpc<std::vector<std::string>(std::string)>(methodManager, "searchItem",
+        "Given an incomplete path to item, return a list of complete path possibles | searchItem(string path)",
+        [this](std::string path) {  return searchItem(std::move(path)); });
+
     m_pimpl->server->BindAndListen(anyrpcPort);
 }
 

--- a/lib/src/Commands/SearchItem.cpp
+++ b/lib/src/Commands/SearchItem.cpp
@@ -1,0 +1,33 @@
+#include "SearchItem.h"
+
+#include <iostream>
+
+#include <Scene/Scene.h>
+
+
+namespace spix {
+namespace cmd {
+
+SearchItem::SearchItem(ItemPath path, bool first, std::promise<std::vector<std::string>> promise)
+: m_path(std::move(path)),
+m_first(first),
+m_promise(std::move(promise))
+{
+}
+
+void SearchItem::execute(CommandEnvironment& env)
+{
+    auto item = env.scene().itemAtPath(m_path);
+    std::vector<std::string> completePath = {};
+
+    if (!item) {
+        env.state().reportError("SearchItem: Item not found: " + m_path.string());
+        m_promise.set_value(completePath);
+        return;
+    }   
+    m_promise.set_value(env.scene().searchEveryCompletePath(m_path));
+    return;
+}
+
+} // namespace cmd
+} // namespace spix

--- a/lib/src/Commands/SearchItem.h
+++ b/lib/src/Commands/SearchItem.h
@@ -1,0 +1,29 @@
+#pragma once
+
+
+#include <Spix/spix_export.h>
+
+#include "Command.h"
+#include <Scene/Events.h>
+#include <Spix/Data/ItemPath.h>
+
+#include <vector>
+#include <future>
+
+namespace spix {
+namespace cmd {
+
+class SPIX_EXPORT SearchItem : public Command {
+public:
+    SearchItem(ItemPath path, bool first, std::promise<std::vector<std::string>> promise);
+
+    void execute(CommandEnvironment& env) override;
+
+private:
+    ItemPath m_path;
+    bool m_first;
+    std::promise<std::vector<std::string>> m_promise;
+};
+
+} // namespace cmd
+} // namespace spix

--- a/lib/src/Scene/Qt/QtItemTools.cpp
+++ b/lib/src/Scene/Qt/QtItemTools.cpp
@@ -8,6 +8,7 @@
 
 #include <QQmlContext>
 #include <QQuickItem>
+#include <QString>
 
 namespace spix {
 namespace qt {
@@ -83,6 +84,44 @@ QObject* FindChildItem(QObject* object, const QString& name)
     }
 
     return nullptr;
+}
+
+void SearchEveryCompletePath(QObject* object, const QString& name, std::vector<std::string>& pathsList, QString path){
+    char sep = '/';
+    
+    if (auto qquickitem = qobject_cast<const QQuickItem*>(object)) {
+        for (auto child : qquickitem->childItems()) {
+            auto current_item_name = GetObjectName(child);
+
+            auto new_path = QString(path);
+            if(!current_item_name.isEmpty()){
+                new_path.append(sep).append(current_item_name);
+            }
+            
+            if (current_item_name == name) {
+                pathsList.push_back(new_path.toStdString().c_str());
+                return;
+            }
+            SearchEveryCompletePath(child, name, pathsList, new_path);
+        }
+    } else {
+        for (auto child : object->children()) {
+            auto current_item_name = GetObjectName(child);
+
+            auto new_path = QString(path);
+            if(!current_item_name.isEmpty()){
+                new_path.append(sep).append(current_item_name);
+            }
+            
+            if (current_item_name == name) {
+                pathsList.push_back(new_path.toStdString().c_str());
+                return;
+            }
+            SearchEveryCompletePath(child, name, pathsList, new_path);
+        }
+    }
+
+    return;
 }
 
 } // namespace qt

--- a/lib/src/Scene/Qt/QtItemTools.h
+++ b/lib/src/Scene/Qt/QtItemTools.h
@@ -9,6 +9,8 @@
 #include <QObject>
 #include <QQuickItem>
 
+#include <vector>
+
 class QString;
 
 namespace spix {
@@ -30,6 +32,8 @@ QString GetObjectName(QObject* object);
  * `children()`, but rather its `childItems()`.
  */
 QObject* FindChildItem(QObject* object, const QString& name);
+
+void SearchEveryCompletePath(QObject* object, const QString& name, std::vector<std::string>& pathsList, QString path);
 
 template <typename T>
 T FindChildItem(QObject* object, const QString& name)

--- a/lib/src/Scene/Qt/QtScene.cpp
+++ b/lib/src/Scene/Qt/QtScene.cpp
@@ -14,6 +14,9 @@
 #include <QObject>
 #include <QQuickItem>
 #include <QQuickWindow>
+#include <QString>
+
+#include <vector>
 
 namespace {
 
@@ -128,6 +131,15 @@ void QtScene::takeScreenshot(const ItemPath& targetItem, const std::string& file
     // crop the window image to the item rect
     auto image = windowImage.copy(imageCropRect);
     image.save(QString::fromStdString(filePath));
+}
+
+std::vector<std::string> QtScene::searchEveryCompletePath(const ItemPath& path){
+    auto windowName = path.rootComponent();
+    QQuickWindow* itemWindow = getQQuickWindowWithName(windowName);
+    std::vector<std::string> pathsList = {};
+    spix::qt::SearchEveryCompletePath(itemWindow, QString(path.subPath(1).string().c_str()), pathsList, QString(path.rootComponent().c_str()));
+    return pathsList;
+
 }
 
 } // namespace spix

--- a/lib/src/Scene/Qt/QtScene.h
+++ b/lib/src/Scene/Qt/QtScene.h
@@ -28,6 +28,7 @@ public:
 
     // Tasks
     void takeScreenshot(const ItemPath& targetItem, const std::string& filePath) override;
+    std::vector<std::string> searchEveryCompletePath(const ItemPath& );
 
 private:
     QtEvents m_events;

--- a/lib/src/Scene/Scene.h
+++ b/lib/src/Scene/Scene.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace spix {
 
@@ -37,6 +38,7 @@ public:
 
     // Tasks
     virtual void takeScreenshot(const ItemPath& targetItem, const std::string& filePath) = 0;
+    virtual std::vector<std::string> searchEveryCompletePath(const ItemPath&) = 0;
 };
 
 } // namespace spix

--- a/lib/src/TestServer.cpp
+++ b/lib/src/TestServer.cpp
@@ -23,6 +23,7 @@
 #include <Commands/Screenshot.h>
 #include <Commands/SetProperty.h>
 #include <Commands/Wait.h>
+#include <Commands/SearchItem.h>
 
 #include <Spix/Events/Identifiers.h>
 
@@ -157,6 +158,16 @@ void TestServer::takeScreenshot(ItemPath targetItem, std::string filePath)
 void TestServer::quit()
 {
     m_cmdExec->enqueueCommand<cmd::Quit>();
+}
+
+std::vector<std::string> TestServer::searchItem(ItemPath path)
+{
+    std::promise<std::vector<std::string>> promise;
+    auto result = promise.get_future();
+    auto cmd = std::make_unique<cmd::SearchItem>(path, false, std::move(promise));
+    m_cmdExec->enqueueCommand(std::move(cmd));
+
+    return result.get();
 }
 
 } // namespace spix


### PR DESCRIPTION
This PR introduces `searchItem` method which allow the client to find and get every (almost complete) path in the Qt tree leading to a specific item (searched by objectName/id as Spix already does).
It is used like thise :
`s.searchItem("mainWindow/<searched item>")`

Here is an example from the RemoteCtrl example : 
![image](https://user-images.githubusercontent.com/79016298/168595515-d49b9c3e-e909-4e30-8372-595bfc535097.png)

## Use Cases
I'm well aware that Spix doesn't require a full path to an item to interact with it, yet searchItem can have many other use cases. 
I personally use it mainly in two ways but I'm sure one can find many others !
 - In the case of complex/big apps the QML code/files can be really huge and scattered, it's not always easy to find the specific object your trying to interact with nor proving it's ID is unique (because of own defined QML objects which are re-used at many places). In that case `searchItem` provides a huge help for finding the path to the interesting object, it can also be **coupled with filters** on the client side (implemented in python then) to be even more effective. It's actually a great **time-saver** while writing tests.
 - For a unit test it can be used as **a logging tool**, this use case has to be improve in my opinion. Currently, I use it to log the accessible items in a ComboBox in the case the test doesn't pass. But I can see that this use *can be extended* in different manners to other widgets 

 I hope you'll see how this method can be integrated in the current Spix toolkit !
 
 ### DISCLAIMER
 
 First, Spix is designed to handle partial paths to an item. Thus, if Spix find an item whose objectName matches the current searched item in the path, it strips the given path from that objectName and doing so won't search for other item which could match this objectName too. 
 Here is an example to illustrate the process:
 ```
 Complete path: mainWindow/tooCommonObjectName/myItem
 
 Qt Tree:
 mainWindow
 |__ some item
      |__ button1
      |__ tooCommonObjectName
           |__ nothing interessant here
 |__ some other item
 |__ tooCommonObjectName
      |__ myItem
 ```
 Spix calls `itemAtPath('mainWindow/tooCommonObjectName/myItem')` which calls `getQQuickItemAtPath('mainWindow/..')` which itself calls `getQQuickItemWithRoot('tooCommonObjectName/myItem', ...)` 
 Now let's suppose the next call is `FindChildItem('tooCommonObjectName', ...)`, because this function use depth-first tree searching it will get to that item :
 ```
 mainWindow
 |__ some item
      |__ button1
      |__ tooCommonObjectName
 ```
 ...and return it, then in the previous scope (`getQQuickItemWithRoot`) a `subItem` is found and the method recursively calls itself stripping the objectName `tooCommonObjectName` from the `path`. 
 However, knowing the full tree I drew above, we **know** that this first occurence of `tooCommonObjectName` isn't the right path to `myItem`. In such a case Spix won't find a path to `myItem` despite the fact that **it exists**. 
 
The problem I highlight here **isn't** the fact that Spix will strip `tooCommonObjectName` without searching for other occurence, nor the fact that `FindChildItem` uses depth-first tree search. 
It's just that paths containing too common object names present a risk that a test crash while it shouldn't. 
Knowing that, one should just **avoid to copy/paste** the complete **path returned by `searchItem`** into its test unit, because too complete path aren't robust against design changes, neither are paths containing too common objectName/ID (which aren't always unique because of the reusing of own defined Qt/QML items.

The second important point is that `searchItem` doesn't take in account the possibility of accessing an item stored as property of another (introduces by PR #2) but I didn't see this feature used in the examples so I figured that it wasn't a big deal.

## Feedback

This is a first version of this method, I would greatly appreciate any help/remark you could make about the feature in itself as well as the implementation !