### PR TITLE
Fix crash when object children iterator is invalidated

### DIFF
--- a/lib/src/Scene/Qt/QtItemTools.cpp
+++ b/lib/src/Scene/Qt/QtItemTools.cpp
@@ -64,8 +64,14 @@ QString GetObjectName(QObject* object)
 
 QObject* FindChildItem(QObject* object, const QString& name)
 {
+    if (object == nullptr) {
+        return nullptr;
+    }
+
+    using Index = QObjectList::size_type;
     if (auto qquickitem = qobject_cast<const QQuickItem*>(object)) {
-        for (auto child : qquickitem->childItems()) {
+        for (Index i = 0; i < qquickitem->childItems().size(); ++i) {
+            auto child = qquickitem->childItems().at(i);
             if (GetObjectName(child) == name) {
                 return child;
             }
@@ -74,7 +80,8 @@ QObject* FindChildItem(QObject* object, const QString& name)
             }
         }
     } else {
-        for (auto child : object->children()) {
+        for (Index i = 0; i < object->children().size(); ++i) {
+            auto child = object->children().at(i);
             if (GetObjectName(child) == name) {
                 return child;
             }


### PR DESCRIPTION
Calling QQmlContext::nameForObject can have side effects, creating new child objects via property read functions.

Reproduction steps:
1. in `examples/Basic/main.qml` change `Window` to `ApplicationWindow`
2. in `examples/Basic/main.cpp` `MyTests::executeTest()` add a line  `std::cout << existsAndVisible(spix::ItemPath("mainWindow/Button_X"));`

`ApplicationWindow` has `screen` property, accessing which adds a new `QQuickScreenInfo` object into `children` list. If this happens during list iteration in range loop, the iterator will be invalidated. Using index based for loop will avoid crash scenario.

Reproducible with Qt 6.2 LTS.