### PR TITLE
Extension of the mouseClick function (add proportion and offset)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(Basic)
 add_subdirectory(GTest)
+add_subdirectory(GTestMouseClickPosition)
 add_subdirectory(ListGridView)
 add_subdirectory(RemoteCtrl)
 add_subdirectory(RepeaterLoader)

--- a/examples/GTestMouseClickPosition/CMakeLists.txt
+++ b/examples/GTestMouseClickPosition/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(SPIX_QT_MAJOR "6" CACHE STRING "Major Qt version to build Spix against")
+
+find_package(Qt${SPIX_QT_MAJOR} COMPONENTS Core Quick REQUIRED)
+find_package(GTest REQUIRED)
+
+add_executable(SpixGTestMouseClickPosition "main.cpp" "qml.qrc")
+target_compile_definitions(SpixGTestMouseClickPosition PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
+target_link_libraries(SpixGTestMouseClickPosition PRIVATE Qt${SPIX_QT_MAJOR}::Core Qt${SPIX_QT_MAJOR}::Quick GTest::GTest Spix)

--- a/examples/GTestMouseClickPosition/ResultsView.qml
+++ b/examples/GTestMouseClickPosition/ResultsView.qml
@@ -1,0 +1,43 @@
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+
+Rectangle {
+    id: resultsView
+    color: "#222222"
+
+    function appendText(text) {
+        resultsArea.append(text);
+    }
+
+    Text {
+        id: resultsTitle
+        text: "Result: "
+        color: "white"
+        font.bold: true
+
+        anchors {
+            top: resultsView.top
+            left: resultsView.left
+            right: resultsView.right
+
+            topMargin: 5
+            leftMargin: 2
+            bottomMargin: 2
+        }
+    }
+    TextEdit {
+        id: resultsArea
+        objectName: "results"
+        color: "white"
+        anchors {
+            top: resultsTitle.bottom
+            left: resultsView.left
+            right: resultsView.right
+            bottom: resultsView.bottom
+
+            leftMargin: 2
+            rightMargin: 2
+            bottomMargin: 2
+        }
+    }
+}

--- a/examples/GTestMouseClickPosition/main.cpp
+++ b/examples/GTestMouseClickPosition/main.cpp
@@ -1,0 +1,153 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+/**
+ * This is a very basic example to demonstrate how to run your UI tests
+ * using GTest. It can be useful when you have to make sure that your
+ * UI tests work well in an existing, GTest based environment.
+ *
+ * Keep in mind that GTest is not designed for UI testing and that the
+ * order of the test execution is not guaranteed. Thus, you should only
+ * have one test per executable.
+ */
+
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <Spix/Events/Identifiers.h>
+#include <Spix/QtQmlBot.h>
+
+#include <atomic>
+#include <gtest/gtest.h>
+
+class SpixGTest;
+static SpixGTest* srv;
+
+class SpixGTest : public spix::TestServer {
+public:
+    SpixGTest(int argc, char* argv[])
+    {
+        m_argc = argc;
+        m_argv = argv;
+    }
+
+    int testResult() { return m_result.load(); }
+
+protected:
+    int m_argc;
+    char** m_argv;
+    std::atomic<int> m_result {0};
+
+    void executeTest() override
+    {
+        srv = this;
+        ::testing::InitGoogleTest(&m_argc, m_argv);
+        auto testResult = RUN_ALL_TESTS();
+        m_result.store(testResult);
+    }
+};
+
+TEST(GTestExample, ProportionAllButtons)
+{
+    const auto upperLeft = spix::Point(0.25, 0.25);
+    const auto upperRigth = spix::Point(0.75, 0.25);
+    const auto lowerLeft = spix::Point(0.25, 0.75);
+    const auto lowerRigth = spix::Point(0.75, 0.75);
+
+    srv->mouseClick(spix::ItemPath("mainWindow/Grid_1"), upperLeft);
+    srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick(spix::ItemPath("mainWindow/Grid_1"), upperRigth);
+    srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick(spix::ItemPath("mainWindow/Grid_1"), lowerLeft);
+    srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick(spix::ItemPath("mainWindow/Grid_1"), lowerRigth);
+    srv->wait(std::chrono::milliseconds(500));
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+
+    auto expected_result = R"RSLT(Button 1 clicked
+Button 2 clicked
+Button 3 clicked
+Button 4 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, ToMuchProportion)
+{
+    // This Test click 200% under the Button 1 => under the Button 1 is Button 3  which will trigger.
+    const auto upperLeft = spix::Point(0.25, 2);
+
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->mouseClick(spix::ItemPath("mainWindow/Button_1"), upperLeft);
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+
+    auto expected_result = R"RSLT(Button 3 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, OffsetAllButtons)
+{
+    const auto upperLeft = spix::Point(100, 100);
+    const auto upperRigth = spix::Point(400, 100);
+    const auto lowerLeft = spix::Point(100, 200);
+    const auto lowerRigth = spix::Point(400, 200);
+
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->mouseClick(spix::ItemPath("mainWindow/Grid_1"), spix::Point(0, 0), upperLeft);
+    srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick(spix::ItemPath("mainWindow/Grid_1"), spix::Point(0, 0), upperRigth);
+    srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick(spix::ItemPath("mainWindow/Grid_1"), spix::Point(0, 0), lowerLeft);
+    srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick(spix::ItemPath("mainWindow/Grid_1"), spix::Point(0, 0), lowerRigth);
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+
+    auto expected_result = R"RSLT(Button 1 clicked
+Button 2 clicked
+Button 3 clicked
+Button 4 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, OffsetOnPositionWithNoButton)
+{
+    const auto centre = spix::Point(320, 120);
+
+    srv->setStringProperty("mainWindow/results", "text", "No Click");
+    srv->mouseClick(spix::ItemPath("mainWindow/Grid_1"), spix::Point(0, 0), centre);
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+
+    auto expected_result = R"RSLT(No Click)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+
+    srv->quit();
+}
+
+int main(int argc, char* argv[])
+{
+    // Init Qt Qml Application
+    QGuiApplication app(argc, argv);
+    QQmlApplicationEngine engine;
+    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
+    if (engine.rootObjects().isEmpty())
+        return -1;
+
+    // Instantiate and run tests
+    SpixGTest tests(argc, argv);
+    auto bot = new spix::QtQmlBot();
+    bot->runTestServer(tests);
+
+    app.exec();
+    return tests.testResult();
+}

--- a/examples/GTestMouseClickPosition/main.cpp
+++ b/examples/GTestMouseClickPosition/main.cpp
@@ -74,7 +74,7 @@ Button 4 clicked)RSLT";
     EXPECT_EQ(result, expected_result);
 }
 
-TEST(GTestExample, ToMuchProportion)
+TEST(GTestExample, TooMuchProportion)
 {
     // This Test click 200% under the Button 1 => under the Button 1 is Button 3  which will trigger.
     const auto upperLeft = spix::Point(0.25, 2);

--- a/examples/GTestMouseClickPosition/main.qml
+++ b/examples/GTestMouseClickPosition/main.qml
@@ -1,0 +1,99 @@
+import QtQuick 2.11
+import QtQuick.Window 2.11
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.11
+
+Window {
+    objectName: "mainWindow"
+    visible: true
+    width: 640
+    height: 480
+    title: qsTr("Spix Example")
+    color: "#111111"
+
+        
+    GridLayout {
+        objectName: "Grid_1"
+        rowSpacing: 20
+        columnSpacing: 20
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: parent.right
+            bottom: parent.verticalCenter
+        }
+        columns: 2
+
+        Button {
+            objectName: "Button_1"
+            text: "Press Me"
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons:  Qt.AllButtons
+                
+                onClicked:
+                {
+                        resultsView.appendText("Button 1 clicked")
+                }
+            }
+        }
+        Button {
+            objectName: "Button_2"
+            text: "Press Me"
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons:  Qt.AllButtons
+                
+                onClicked:
+                {
+                        resultsView.appendText("Button 2 clicked")
+                }
+            }
+        }
+        Button {
+            objectName: "Button_3"
+            text: "Press Me"
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons:  Qt.AllButtons
+                
+                onClicked:
+                {
+                        resultsView.appendText("Button 3 clicked")
+                }
+            }
+        }
+        Button {
+            objectName: "Button_4"
+            text: "Press Me"
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons:  Qt.AllButtons
+                
+                onClicked:
+                {
+                        resultsView.appendText("Button 4 clicked")
+                }
+            }
+        }
+    }
+
+
+    ResultsView {
+        id: resultsView
+        anchors {
+            top: parent.verticalCenter
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+    }
+}

--- a/examples/GTestMouseClickPosition/qml.qrc
+++ b/examples/GTestMouseClickPosition/qml.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/">
+        <file>main.qml</file>
+        <file>ResultsView.qml</file>
+    </qresource>
+</RCC>

--- a/lib/include/Spix/TestServer.h
+++ b/lib/include/Spix/TestServer.h
@@ -48,6 +48,8 @@ public:
     void wait(std::chrono::milliseconds waitTime);
     void mouseClick(ItemPath path);
     void mouseClick(ItemPath path, MouseButton mouseButton);
+    void mouseClick(ItemPath path, Point proportion);
+    void mouseClick(ItemPath path, Point proportion, Point offset);
     void mouseBeginDrag(ItemPath path);
     void mouseEndDrag(ItemPath path);
     void mouseDropUrls(ItemPath path, const std::vector<std::string>& urls);

--- a/lib/src/AnyRpcServer.cpp
+++ b/lib/src/AnyRpcServer.cpp
@@ -37,6 +37,25 @@ AnyRpcServer::AnyRpcServer(int anyrpcPort)
         "mouseButton)",
         [this](std::string path, int mouseButton) { mouseClick(std::move(path), mouseButton); });
 
+    utils::AddFunctionToAnyRpc<void(std::string, double, double)>(methodManager, "mouseClickWithOffset",
+        "Click on the object at the given path with the given offset"
+        "(absolute pixel) | mouseClickWithOffset(string path, float "
+        "offsetX, float offsetY)",
+        [this](std::string path, double offsetX, double offsetY) {
+            auto proportion = Point(0, 0);
+            auto offset = Point(offsetX, offsetY);
+            mouseClick(std::move(path), proportion, offset);
+        });
+
+    utils::AddFunctionToAnyRpc<void(std::string, double, double)>(methodManager, "mouseClickWithProportion",
+        "Click on the object at the given path with the given proportion (In percent) | "
+        "mouseClickWithProportion(string path, float "
+        "proportionX, float proportionY)",
+        [this](std::string path, double proportionX, double proportionY) {
+            auto proportion = Point(proportionX, proportionY);
+            mouseClick(std::move(path), proportion);
+        });
+
     utils::AddFunctionToAnyRpc<void(std::string)>(methodManager, "mouseBeginDrag",
         "Begin a drag with the mouse | mouseBeginDrag(string path)",
         [this](std::string path) { mouseBeginDrag(std::move(path)); });

--- a/lib/src/AnyRpcServer.cpp
+++ b/lib/src/AnyRpcServer.cpp
@@ -48,9 +48,8 @@ AnyRpcServer::AnyRpcServer(int anyrpcPort)
         });
 
     utils::AddFunctionToAnyRpc<void(std::string, double, double)>(methodManager, "mouseClickWithProportion",
-        "Click on the object at the given path with the given proportion (In percent) | "
-        "mouseClickWithProportion(string path, float "
-        "proportionX, float proportionY)",
+        "Click on the object at the given path with the given proportion (In percent)"
+        "| mouseClickWithProportion(string path, float proportionX, float proportionY)",
         [this](std::string path, double proportionX, double proportionY) {
             auto proportion = Point(proportionX, proportionY);
             mouseClick(std::move(path), proportion);

--- a/lib/src/TestServer.cpp
+++ b/lib/src/TestServer.cpp
@@ -69,6 +69,18 @@ void TestServer::mouseClick(ItemPath path)
     m_cmdExec->enqueueCommand<cmd::ClickOnItem>(path, spix::MouseButtons::Left);
 }
 
+void TestServer::mouseClick(ItemPath path, Point proportion)
+{
+    auto pathWithProportion = ItemPosition(path.string(), proportion);
+    m_cmdExec->enqueueCommand<cmd::ClickOnItem>(pathWithProportion, spix::MouseButtons::Left);
+}
+
+void TestServer::mouseClick(ItemPath path, Point proportion, Point offset)
+{
+    auto pathWithOffset = ItemPosition(path.string(), proportion, offset);
+    m_cmdExec->enqueueCommand<cmd::ClickOnItem>(pathWithOffset, spix::MouseButtons::Left);
+}
+
 void TestServer::mouseClick(ItemPath path, MouseButton mouseButton)
 {
     m_cmdExec->enqueueCommand<cmd::ClickOnItem>(path, mouseButton);

--- a/lib/src/Utils/AnyRpcFunction.h
+++ b/lib/src/Utils/AnyRpcFunction.h
@@ -70,6 +70,15 @@ int unpackAnyRpcParam(anyrpc::Value& value)
 }
 
 template <>
+double unpackAnyRpcParam(anyrpc::Value& value)
+{
+    if (!value.IsNumber()) {
+        throw anyrpc::AnyRpcException(anyrpc::AnyRpcErrorInvalidParams, "Invalid parameters. Expected double.");
+    }
+    return value.GetDouble();
+}
+
+template <>
 unsigned unpackAnyRpcParam(anyrpc::Value& value)
 {
     if (!value.IsUint()) {


### PR DESCRIPTION
Add new parameters (proportion and offset) to the mouseClick function. For the end User this will end in two new Functions `mouseClickWithProportion` and `mouseClickWithOffset`.  It will be possible to click e.g. sliderarea at certain positions.

<img src="https://github.com/faaxm/spix/assets/48125666/f4688441-669f-430f-a569-8cc0c7298475" width="400"/>

Can be used in Python, for example, as follows:
```python
from xmlrpc.client import ServerProxy

session = ServerProxy('http://localhost:9000')
session.mouseClickWithProportion('mainWindow/sliderarea', 0.4, 0.5)
```