### PR TITLE
Add Documentation for command

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,27 @@ s.invokeMethod("root/item", "test", [34])
 s.invokeMethod("root/item", "test", [{}])
 ```
 
+###  Using generic/custom command
+You can register your own commands in your C++ Application.
+It could be useful for Example to reset your hole Application.
+
+Register the Commands in your C++ Code:
+```C++
+    ...
+    spix::AnyRpcServer server;
+    server.setGenericCommandHandler([](std::string command, std::string payload) {
+        // do whatever needs to be done
+    });
+    ...
+```
+Now you have all capabilities that the Application has.
+The Payload handling must be done by your own.
+
+You can call this in Python like this:
+```python
+s.command('reset', 'now')
+```
+
 ## Two modes of operation
 In general, Spix can be used in two ways, which are different in how events are generated and sent
 to your application:

--- a/lib/src/AnyRpcServer.cpp
+++ b/lib/src/AnyRpcServer.cpp
@@ -102,7 +102,7 @@ AnyRpcServer::AnyRpcServer(int anyrpcPort)
     utils::AddFunctionToAnyRpc<void()>(methodManager, "quit", "Close the app | quit()", [this] { quit(); });
 
     utils::AddFunctionToAnyRpc<void(std::string, std::string)>(methodManager, "command",
-        "Executes a generic command | command(string command, string payload)",
+        "Executes a generic/custom command | command(string command, string payload)",
         [this](std::string command, std::string payload) { genericCommand(command, payload); });
 
     m_pimpl->server->BindAndListen(anyrpcPort);


### PR DESCRIPTION
As I have just spent an hour trying to understand what the command `command` does, I have documented this in the README. I also find the word generic a little confusing, so I called it `generic/custom` in the Documentation.