### PR TITLE
Better Filter on Path (Text, Type and Property)

### DIFF
--- a/examples/Basic/main.qml
+++ b/examples/Basic/main.qml
@@ -23,34 +23,33 @@ Window {
         Button {
             objectName: "Button_1"
             text: "Press Me"
-			MouseArea {
-				anchors.fill: parent
-				acceptedButtons:  Qt.AllButtons
-				
-				onClicked:
-				{
-					if(mouse.button & Qt.RightButton)
-						resultsView.appendText("Button 1 right clicked")
-					else
-						resultsView.appendText("Button 1 clicked")
-				}
-			}
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons:  Qt.AllButtons
+
+                onClicked: function (mouse)
+                {
+                    if(mouse.button & Qt.RightButton)
+                        resultsView.appendText("Button 1 right clicked")
+                    else
+                        resultsView.appendText("Button 1 clicked")
+                }
+            }
         }
         Button {
             objectName: "Button_2"
             text: "Or Click Me"
-			MouseArea {
-				anchors.fill: parent
-				acceptedButtons:  Qt.AllButtons
-				
-				onClicked:
-				{
-					if(mouse.button & Qt.RightButton)
-						resultsView.appendText("Button 2 right clicked")
-					else
-						resultsView.appendText("Button 2 clicked")
-				}
-			}
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons:  Qt.AllButtons
+
+                onClicked: function (mouse) {
+                    if(mouse.button & Qt.RightButton)
+                        resultsView.appendText("Button 2 right clicked")
+                    else
+                        resultsView.appendText("Button 2 clicked")
+                }
+            }
         }
     }
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(Basic)
 add_subdirectory(GTest)
 add_subdirectory(GTestMouseClickPosition)
+add_subdirectory(GTestTypeFinder)
 add_subdirectory(ListGridView)
 add_subdirectory(RemoteCtrl)
 add_subdirectory(RepeaterLoader)

--- a/examples/GTest/main.cpp
+++ b/examples/GTest/main.cpp
@@ -119,29 +119,13 @@ TEST(GTestExample, SearchType)
     EXPECT_EQ(result, expected_result);
 }
 
-TEST(GTestExample, SearchTypeAndTextCombined)
-{
-    // Clean Output
-    srv->setStringProperty("mainWindow/results", "text", "");
-    srv->wait(std::chrono::milliseconds(500));
-    // Search for Type in the center of a Path
-    srv->mouseClick(spix::ItemPath("mainWindow/#Rectangle/\"Or Click Me\""));
-    srv->wait(std::chrono::milliseconds(500));
-
-    auto result = srv->getStringProperty("mainWindow/results", "text");
-    auto expected_result = R"RSLT(Button 2 clicked)RSLT";
-
-    EXPECT_EQ(result, expected_result);
-    srv->quit();
-}
-
 TEST(GTestExample, SearchWrongType)
 {
     // Clean Output
     srv->setStringProperty("mainWindow/results", "text", "");
     srv->wait(std::chrono::milliseconds(500));
     // Serach for Type Button in the end of a Path
-    srv->mouseClick(spix::ItemPath("mainWindow/#Button_1")); //evil: its a name, not a type
+    srv->mouseClick(spix::ItemPath("mainWindow/#Button_1")); // evil: its a name, not a type
     srv->wait(std::chrono::milliseconds(500));
 
     auto result = srv->getStringProperty("mainWindow/results", "text");
@@ -156,13 +140,29 @@ TEST(GTestExample, SearchByValue)
     srv->setStringProperty("mainWindow/results", "text", "");
     srv->wait(std::chrono::milliseconds(500));
     // Serach for Type Button in the end of a Path
-    srv->mouseClick(spix::ItemPath("mainWindow/(width=99)")); //Button2 width
+    srv->mouseClick(spix::ItemPath("mainWindow/(width=99)")); // Button2 width
     srv->wait(std::chrono::milliseconds(500));
 
     auto result = srv->getStringProperty("mainWindow/results", "text");
     auto expected_result = R"RSLT(Button 2 clicked)RSLT";
 
     EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, SearchTypeAndTextCombined)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->wait(std::chrono::milliseconds(500));
+    // Search for Type in the center of a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Rectangle/\"Or Click Me\""));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(Button 2 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+    srv->quit();
 }
 
 int main(int argc, char* argv[])

--- a/examples/GTest/main.cpp
+++ b/examples/GTest/main.cpp
@@ -87,8 +87,82 @@ Button 2 control clicked
 Button 2 shift control clicked)RSLT";
 
     EXPECT_EQ(result, expected_result);
+}
 
+TEST(GTestExample, SearchText)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->wait(std::chrono::milliseconds(500));
+    // Look for a Text "Press Me"
+    srv->mouseClick(spix::ItemPath("mainWindow/\"Press Me\""));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(Button 1 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, SearchType)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->wait(std::chrono::milliseconds(500));
+    // Serach for Type Button in the end of a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Button"));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(Button 1 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, SearchTypeAndTextCombined)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->wait(std::chrono::milliseconds(500));
+    // Search for Type in the center of a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Rectangle/\"Or Click Me\""));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(Button 2 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
     srv->quit();
+}
+
+TEST(GTestExample, SearchWrongType)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->wait(std::chrono::milliseconds(500));
+    // Serach for Type Button in the end of a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Button_1")); //evil: its a name, not a type
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT()RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, SearchByValue)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->wait(std::chrono::milliseconds(500));
+    // Serach for Type Button in the end of a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/(width=99)")); //Button2 width
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(Button 2 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
 }
 
 int main(int argc, char* argv[])

--- a/examples/GTest/main.qml
+++ b/examples/GTest/main.qml
@@ -27,8 +27,7 @@ Window {
                 anchors.fill: parent
                 acceptedButtons:  Qt.AllButtons
 
-                onClicked:
-                {
+                onClicked: function (mouse) {
                     if(mouse.button & Qt.RightButton)
                         resultsView.appendText("Button 1 right clicked")
                     else if ((mouse.button == Qt.LeftButton) && (mouse.modifiers & Qt.ShiftModifier))
@@ -52,8 +51,7 @@ Window {
                     anchors.fill: parent
                     acceptedButtons:  Qt.AllButtons
                     
-                    onClicked:
-                    {
+                    onClicked: function (mouse) {
                         if(mouse.button & Qt.RightButton)
                             resultsView.appendText("Button 2 right clicked")
                         else if ((mouse.modifiers & Qt.ControlModifier) && (mouse.modifiers &Qt.ShiftModifier))

--- a/examples/GTest/main.qml
+++ b/examples/GTest/main.qml
@@ -23,45 +23,50 @@ Window {
         Button {
             objectName: "Button_1"
             text: "Press Me"
-			MouseArea {
-				anchors.fill: parent
-				acceptedButtons:  Qt.AllButtons
-				
-				onClicked:
-				{
-					if(mouse.button & Qt.RightButton)
-						resultsView.appendText("Button 1 right clicked")
-					else if ((mouse.button == Qt.LeftButton) && (mouse.modifiers & Qt.ShiftModifier))
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons:  Qt.AllButtons
+
+                onClicked:
+                {
+                    if(mouse.button & Qt.RightButton)
+                        resultsView.appendText("Button 1 right clicked")
+                    else if ((mouse.button == Qt.LeftButton) && (mouse.modifiers & Qt.ShiftModifier))
                         resultsView.appendText("Button 1 shift clicked")
                     else if ((mouse.button == Qt.LeftButton) && (mouse.modifiers & Qt.ControlModifier))
                         resultsView.appendText("Button 1 shift control clicked")
                     else
-						resultsView.appendText("Button 1 clicked")
-				}
-			}
+                        resultsView.appendText("Button 1 clicked")
+                }
+            }
         }
-        Button {
-            objectName: "Button_2"
-            text: "Or Click Me"
-			MouseArea {
-				anchors.fill: parent
-				acceptedButtons:  Qt.AllButtons
-				
-				onClicked:
-				{
-					if(mouse.button & Qt.RightButton)
-						resultsView.appendText("Button 2 right clicked")
-					else if ((mouse.button == Qt.LeftButton) && (mouse.modifiers & Qt.ShiftModifier))
-                        if ((mouse.modifiers & Qt.ControlModifier))
+        Rectangle {
+            width: 100
+            height: 100
+            color: "red"
+            Button {
+                objectName: "Button_2"
+                text: "Or Click Me"
+                width: 99
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons:  Qt.AllButtons
+                    
+                    onClicked:
+                    {
+                        if(mouse.button & Qt.RightButton)
+                            resultsView.appendText("Button 2 right clicked")
+                        else if ((mouse.modifiers & Qt.ControlModifier) && (mouse.modifiers &Qt.ShiftModifier))
                             resultsView.appendText("Button 2 shift control clicked")
+                        else if ((mouse.modifiers & Qt.ShiftModifier))
+                            resultsView.appendText("Button 2 shift clicked")
+                        else if ((mouse.button === Qt.LeftButton) && (mouse.modifiers & Qt.ControlModifier))
+                            resultsView.appendText("Button 2 control clicked")
                         else
-                        resultsView.appendText("Button 2 shift clicked")
-                    else if ((mouse.button == Qt.LeftButton) && (mouse.modifiers & Qt.ControlModifier))
-                        resultsView.appendText("Button 2 control clicked")
-                    else
-						resultsView.appendText("Button 2 clicked")
-				}
-			}
+                            resultsView.appendText("Button 2 clicked")
+                    }
+                }
+            }
         }
     }
 

--- a/examples/GTestTypeFinder/CMakeLists.txt
+++ b/examples/GTestTypeFinder/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(SPIX_QT_MAJOR "6" CACHE STRING "Major Qt version to build Spix against")
+
+find_package(Qt${SPIX_QT_MAJOR} COMPONENTS Core Quick REQUIRED)
+find_package(GTest REQUIRED)
+
+add_executable(SpixGTestTypeFinder "main.cpp" "qml.qrc")
+target_compile_definitions(SpixGTestTypeFinder PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
+target_link_libraries(SpixGTestTypeFinder PRIVATE Qt${SPIX_QT_MAJOR}::Core Qt${SPIX_QT_MAJOR}::Quick GTest::GTest Spix)

--- a/examples/GTestTypeFinder/ResultsView.qml
+++ b/examples/GTestTypeFinder/ResultsView.qml
@@ -1,0 +1,43 @@
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+
+Rectangle {
+    id: resultsView
+    color: "#222222"
+
+    function appendText(text) {
+        resultsArea.append(text);
+    }
+
+    Text {
+        id: resultsTitle
+        text: "Result: "
+        color: "white"
+        font.bold: true
+
+        anchors {
+            top: resultsView.top
+            left: resultsView.left
+            right: resultsView.right
+
+            topMargin: 5
+            leftMargin: 2
+            bottomMargin: 2
+        }
+    }
+    TextEdit {
+        id: resultsArea
+        objectName: "results"
+        color: "white"
+        anchors {
+            top: resultsTitle.bottom
+            left: resultsView.left
+            right: resultsView.right
+            bottom: resultsView.bottom
+
+            leftMargin: 2
+            rightMargin: 2
+            bottomMargin: 2
+        }
+    }
+}

--- a/examples/GTestTypeFinder/main.cpp
+++ b/examples/GTestTypeFinder/main.cpp
@@ -1,0 +1,171 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+/**
+ * This is a very basic example to demonstrate how to run your UI tests
+ * using GTest. It can be useful when you have to make sure that your
+ * UI tests work well in an existing, GTest based environment.
+ *
+ * Keep in mind that GTest is not designed for UI testing and that the
+ * order of the test execution is not guaranteed. Thus, you should only
+ * have one test per executable.
+ */
+
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <Spix/Events/Identifiers.h>
+#include <Spix/QtQmlBot.h>
+
+#include <atomic>
+#include <gtest/gtest.h>
+
+class SpixGTest;
+static SpixGTest* srv;
+
+class SpixGTest : public spix::TestServer {
+public:
+    SpixGTest(int argc, char* argv[])
+    {
+        m_argc = argc;
+        m_argv = argv;
+    }
+
+    int testResult() { return m_result.load(); }
+
+protected:
+    int m_argc;
+    char** m_argv;
+    std::atomic<int> m_result {0};
+
+    void executeTest() override
+    {
+        srv = this;
+        ::testing::InitGoogleTest(&m_argc, m_argv);
+        auto testResult = RUN_ALL_TESTS();
+        m_result.store(testResult);
+    }
+};
+
+TEST(GTestExample, SearchTypeCentre)
+{
+    // Search for mutible Types in a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Rectangle/#Rectangle/#Rectangle/\"Click Me\""));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(Button 2 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, SearchTypeCentreShortened)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->wait(std::chrono::milliseconds(500));
+    // Search for mutible Types in a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Rectangle/#Rectangle/\"Click Me\""));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(Button 2 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, SearchWrongText)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "No Click");
+    srv->wait(std::chrono::milliseconds(500));
+    // Search for mutible Types in a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Rectangle/#Rectangle\"Not on the Screen\""));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(No Click)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, SearchTypeInTwoReacts)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->wait(std::chrono::milliseconds(500));
+    // Search for mutible Types in a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Rectangle/#Rectangle/\"Click Me\""));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(Button 2 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, SearchTypeInTwoReactsWithWrongButton)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "No Click");
+    srv->wait(std::chrono::milliseconds(500));
+    // Search for mutible Types in a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Rectangle/#Rectangle/\"Click You\""));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(No Click)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, SearchTypeCentreFirstButton)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "");
+    srv->wait(std::chrono::milliseconds(500));
+    // Search for mutible Types in a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Rectangle/\"Click Me\""));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(Button 1 clicked)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+}
+
+TEST(GTestExample, SearchTypeToManyRectangles)
+{
+    // Clean Output
+    srv->setStringProperty("mainWindow/results", "text", "No Click");
+    srv->wait(std::chrono::milliseconds(500));
+    // Search for mutible Types in a Path
+    srv->mouseClick(spix::ItemPath("mainWindow/#Rectangle/#Rectangle/#Rectangle/#Rectangle"));
+    srv->wait(std::chrono::milliseconds(500));
+
+    auto result = srv->getStringProperty("mainWindow/results", "text");
+    auto expected_result = R"RSLT(No Click)RSLT";
+
+    EXPECT_EQ(result, expected_result);
+    srv->quit();
+}
+
+int main(int argc, char* argv[])
+{
+    // Init Qt Qml Application
+    QGuiApplication app(argc, argv);
+    QQmlApplicationEngine engine;
+    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
+    if (engine.rootObjects().isEmpty())
+        return -1;
+
+    // Instantiate and run tests
+    SpixGTest tests(argc, argv);
+    auto bot = new spix::QtQmlBot();
+    bot->runTestServer(tests);
+
+    app.exec();
+    return tests.testResult();
+}

--- a/examples/GTestTypeFinder/main.qml
+++ b/examples/GTestTypeFinder/main.qml
@@ -1,0 +1,115 @@
+import QtQuick 2.11
+import QtQuick.Window 2.11
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.11
+
+Window {
+    objectName: "mainWindow"
+    visible: true
+    width: 640
+    height: 480
+    title: qsTr("Spix Example")
+    color: "#111111"
+
+    RowLayout {
+
+        anchors {
+            top: parent.top
+            left: parent.left
+            topMargin: 5
+            leftMargin: 5
+        }
+
+        Rectangle {
+            property string test_id: "red_rect"
+            width: 200
+            height: 200
+            color: "red"
+
+            Text {
+                property string test_id: "button 1"
+                objectName: "Button_1"
+                text: "Click Me"
+                anchors.right: parent.right
+                anchors {
+                    bottom: parent.bottom
+                }
+                    
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons:  Qt.AllButtons
+                    onClicked:
+                        {
+                            if(mouse.button & Qt.RightButton)
+                                resultsView.appendText("Button 1 right clicked")
+                            else
+                                resultsView.appendText("Button 1 clicked")
+                        }
+                    }
+                }
+
+            Text {
+                property string test_id: "button_3"
+                objectName: "Button_3"
+                text: "Click You"
+                anchors.left: parent.left
+                anchors {
+                    bottom: parent.bottom
+                }
+                
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons:  Qt.AllButtons
+                    onClicked:
+                        {
+                            if(mouse.button & Qt.RightButton)
+                                resultsView.appendText("Button 3 right clicked")
+                            else
+                                resultsView.appendText("Button 3 clicked")
+                        }
+                    }
+            }
+
+            Rectangle {
+                property string test_id: "green_rect"
+                width: 150
+                height: 150
+                color: "green"
+                
+                Rectangle {
+                    property string test_id: "blue_rect"
+                    width: 100
+                    height: 100
+                    color: "blue"
+                    Text {
+                        property string test_id: "button 2"
+                        objectName: "Button_2"
+                        text: "Click Me"
+                        MouseArea {
+                            anchors.fill: parent
+                            acceptedButtons:  Qt.AllButtons
+                            
+                            onClicked:
+                            {
+                                if(mouse.button & Qt.RightButton)
+                                    resultsView.appendText("Button 2 right clicked")
+                                else
+                                    resultsView.appendText("Button 2 clicked")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    ResultsView {
+        id: resultsView
+        anchors {
+            top: parent.verticalCenter
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+    }
+}

--- a/examples/GTestTypeFinder/qml.qrc
+++ b/examples/GTestTypeFinder/qml.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/">
+        <file>main.qml</file>
+        <file>ResultsView.qml</file>
+    </qresource>
+</RCC>

--- a/lib/src/Data/ItemPath.cpp
+++ b/lib/src/Data/ItemPath.cpp
@@ -24,6 +24,12 @@ ItemPath::ItemPath(const std::string& path)
 
     while (pathss) {
         std::string component;
+        if (pathss.peek() == '\"') {
+            getline(pathss, component, '\"');
+            getline(pathss, component, '\"');
+            component = '\"' + component + '\"';
+            m_components.push_back(std::move(component));
+        }
         getline(pathss, component, '/');
         if (component.length() > 0) {
             m_components.push_back(std::move(component));

--- a/lib/src/Data/ItemPath.cpp
+++ b/lib/src/Data/ItemPath.cpp
@@ -30,6 +30,14 @@ ItemPath::ItemPath(const std::string& path)
             component = '\"' + component + '\"';
             m_components.push_back(std::move(component));
         }
+
+        if (pathss.peek() == '(') {
+            getline(pathss, component, '(');
+            getline(pathss, component, ')');
+            component = '(' + component + ')';
+            m_components.push_back(std::move(component));
+        }
+
         getline(pathss, component, '/');
         if (component.length() > 0) {
             m_components.push_back(std::move(component));

--- a/lib/src/Scene/Qt/QtItemTools.h
+++ b/lib/src/Scene/Qt/QtItemTools.h
@@ -12,6 +12,7 @@
 #include <QObject>
 #include <QQuickItem>
 #include <QVariant>
+#include <optional>
 
 class QString;
 
@@ -25,7 +26,8 @@ QQuickItem* RepeaterChildAtIndex(QQuickItem* repeater, int index);
 QQuickItem* RepeaterChildWithName(QQuickItem* repeater, const QString& name);
 
 QString GetObjectName(QObject* object);
-
+QString TextPropertyByObject(QObject* object);
+QString TypeByObject(QObject* object);
 /**
  * @brief Find a child object with the given name.
  *
@@ -33,12 +35,21 @@ QString GetObjectName(QObject* object);
  * encounters a `QQuickItem`, it no longer iterates over the object's
  * `children()`, but rather its `childItems()`.
  */
-QObject* FindChildItem(QObject* object, const QString& name);
+QObject* FindChildItem(QObject* object, const QString& name, const std::optional<QString>& propertyText,
+    const std::optional<QString>& type);
+QVector<QObject*> FindChildItems(QObject* object, const std::optional<QString>& type);
+
+template <typename T>
+T FindChildItem(QObject* object, const QString& name, const std::optional<QString>& propertyText,
+    const std::optional<QString>& type)
+{
+    return qobject_cast<T>(FindChildItem(object, name, propertyText, type));
+}
 
 template <typename T>
 T FindChildItem(QObject* object, const QString& name)
 {
-    return qobject_cast<T>(FindChildItem(object, name));
+    return qobject_cast<T>(FindChildItem(object, name, {}, {}));
 }
 
 using QMLReturnVariant = std::variant<std::nullptr_t, bool, int, float, double, QString, QDateTime, QVariant>;

--- a/lib/src/Scene/Qt/QtItemTools.h
+++ b/lib/src/Scene/Qt/QtItemTools.h
@@ -26,7 +26,7 @@ QQuickItem* RepeaterChildAtIndex(QQuickItem* repeater, int index);
 QQuickItem* RepeaterChildWithName(QQuickItem* repeater, const QString& name);
 
 QString GetObjectName(QObject* object);
-QString TextPropertyByObject(QObject* object);
+QString PropertValueByObject(QObject* object, QString propertyName);
 QString TypeByObject(QObject* object);
 /**
  * @brief Find a child object with the given name.
@@ -35,21 +35,21 @@ QString TypeByObject(QObject* object);
  * encounters a `QQuickItem`, it no longer iterates over the object's
  * `children()`, but rather its `childItems()`.
  */
-QObject* FindChildItem(QObject* object, const QString& name, const std::optional<QString>& propertyText,
-    const std::optional<QString>& type);
+QObject* FindChildItem(QObject* object, const std::optional<QString>& name, const std::optional<QString>& propertyName,
+    const std::optional<QString>& propertyValue, const std::optional<QString>& type);
 QVector<QObject*> FindChildItems(QObject* object, const std::optional<QString>& type);
 
 template <typename T>
-T FindChildItem(QObject* object, const QString& name, const std::optional<QString>& propertyText,
-    const std::optional<QString>& type)
+T FindChildItem(QObject* object, const std::optional<QString>& name, const std::optional<QString>& propertyName,
+    const std::optional<QString>& propertyValue, const std::optional<QString>& type)
 {
-    return qobject_cast<T>(FindChildItem(object, name, propertyText, type));
+    return qobject_cast<T>(FindChildItem(object, name, propertyName, propertyValue, type));
 }
 
 template <typename T>
 T FindChildItem(QObject* object, const QString& name)
 {
-    return qobject_cast<T>(FindChildItem(object, name, {}, {}));
+    return qobject_cast<T>(FindChildItem(object, name, {}, {}, {}));
 }
 
 using QMLReturnVariant = std::variant<std::nullptr_t, bool, int, float, double, QString, QDateTime, QVariant>;

--- a/lib/src/Scene/Qt/QtScene.cpp
+++ b/lib/src/Scene/Qt/QtScene.cpp
@@ -22,8 +22,10 @@ namespace {
 QString getNameForObject(QObject* object)
 {
     QString name;
-    if (spix::qt::TextPropertyByObject(object) != "") {
-        name = "\"" + spix::qt::TextPropertyByObject(object) + "\"";
+    if (spix::qt::PropertValueByObject(object, QString::fromStdString("text")) != "") {
+        name = "\"" + spix::qt::PropertValueByObject(object, QString::fromStdString("text")) + "\"";
+    } else if (spix::qt::PropertValueByObject(object, QString::fromStdString("source")) != "") {
+        name = "(source=" + spix::qt::PropertValueByObject(object, QString::fromStdString("source")) + ")";
     } else if (spix::qt::GetObjectName(object) != "") {
         name = spix::qt::GetObjectName(object);
     } else {
@@ -72,14 +74,15 @@ QQuickItem* getQQuickItemWithRoot(const spix::ItemPath& path, QObject* root)
         }
 
     } else if (itemName.compare(0, 1, "\"") == 0) {
-        auto propertyName = itemName.substr(1);
-        QVariant propertyValue = root->property(propertyName.c_str());
-
+        // remove ""
         size_t found = itemName.find("\"");
         auto searchText = itemName.substr(found + 1, itemName.length() - 2);
-        subItem = spix::qt::FindChildItem<QQuickItem*>(root, itemName.c_str(), QString::fromStdString(searchText), {});
+
+        subItem = spix::qt::FindChildItem<QQuickItem*>(
+            root, itemName.c_str(), QString::fromStdString("text"), QString::fromStdString(searchText), {});
 
     } else if (itemName.compare(0, 1, "#") == 0) {
+        // remove #
         size_t found = itemName.find("#");
         auto type = QString::fromStdString(itemName.substr(found + 1));
 
@@ -93,10 +96,20 @@ QQuickItem* getQQuickItemWithRoot(const spix::ItemPath& path, QObject* root)
                 }
             }
         } else {
-            subItem = spix::qt::FindChildItem<QQuickItem*>(root, itemName.c_str(), {}, type);
+            subItem = spix::qt::FindChildItem<QQuickItem*>(root, {}, {}, {}, type);
             return subItem;
         }
+    } else if (itemName.compare(0, 1, "(") == 0) {
+        // remove ()
+        size_t foundBracketSign = itemName.find('(');
+        auto searchText = itemName.substr(foundBracketSign + 1, itemName.length() - 2);
 
+        // Split in to property and value
+        size_t foundEqualSign = searchText.find('=');
+        auto property = QString::fromStdString(searchText.substr(0, foundEqualSign));
+        auto value = QString::fromStdString(searchText.substr(foundEqualSign + 1));
+
+        subItem = spix::qt::FindChildItem<QQuickItem*>(root, itemName.c_str(), property, value, {});
     } else if (rootClassName == spix::qt::repeater_class_name) {
         QQuickItem* repeater = static_cast<QQuickItem*>(root);
         subItem = spix::qt::RepeaterChildWithName(repeater, QString::fromStdString(itemName));


### PR DESCRIPTION
I added the option in Path to use `#` for finding types of a Qml Object.
Finding Text with `"yout text"`. And a filter for looking at Properties `(source=qrc:/menu/back.png)`.

Example in Python: 
```python 
from xmlrpc.client import ServerProxy

# Connect to the application
session = ServerProxy('http://192.168.178.142:9000')

# Looking for Type
session.existsAndVisible('mainWindow/#Rectangle')

# Looking for Text
session.existsAndVisible('mainWindow/"Click Me"')
```

This can then be used in all spix functions.

For the Property Filter, I use `()` so select them. They also must have a `=` to look what is the Value and what is the Property.
```python
session.mouseClick('mainWindow/(source=qrc:/menu/back.png)')
```
It is very cool when you use this on a back arrow Button.