### PR TITLE
Adding the function wait for path

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -64,6 +64,8 @@ set(SOURCES
     src/Commands/SetProperty.h
     src/Commands/Wait.cpp
     src/Commands/Wait.h
+    src/Commands/WaitForPath.cpp
+    src/Commands/WaitForPath.h
 
     src/CommandExecuter/CommandEnvironment.cpp
     src/CommandExecuter/CommandEnvironment.h

--- a/lib/include/Spix/TestServer.h
+++ b/lib/include/Spix/TestServer.h
@@ -62,6 +62,7 @@ public:
     Rect getBoundingBox(ItemPath path);
     bool existsAndVisible(ItemPath path);
     std::vector<std::string> getErrors();
+    bool waitForPath(ItemPath path, std::chrono::milliseconds maxWaitTime);
 
     void takeScreenshot(ItemPath targetItem, std::string filePath);
     void quit();

--- a/lib/src/AnyRpcServer.cpp
+++ b/lib/src/AnyRpcServer.cpp
@@ -88,6 +88,11 @@ AnyRpcServer::AnyRpcServer(int anyrpcPort)
         "Returns true if the given object exists | existsAndVisible(string path) : bool exists_and_visible",
         [this](std::string path) { return existsAndVisible(std::move(path)); });
 
+    utils::AddFunctionToAnyRpc<bool(std::string, int)>(methodManager, "waitForPath",
+        "Returns true if the given object exists and the time is not expired | waitForPath(string path, int "
+        "millisecondsToWait) : bool exists_and_visible",
+        [this](std::string path, int ms) { return waitForPath(std::move(path), std::chrono::milliseconds(ms)); });
+
     utils::AddFunctionToAnyRpc<std::vector<std::string>()>(methodManager, "getErrors",
         "Returns internal errors that occurred during test execution | getErrors() : (strings) [error1, ...]",
         [this]() { return getErrors(); });

--- a/lib/src/CommandExecuter/CommandExecuter.cpp
+++ b/lib/src/CommandExecuter/CommandExecuter.cpp
@@ -45,7 +45,7 @@ void CommandExecuter::processCommands(Scene& scene)
     while (!m_commandQueue.empty()) {
         auto& queuedCmd = m_commandQueue.front();
 
-        if (!queuedCmd->canExecuteNow())
+        if (!queuedCmd->canExecuteNow(env))
             break;
 
         // We can execute the command now.

--- a/lib/src/Commands/Command.cpp
+++ b/lib/src/Commands/Command.cpp
@@ -9,7 +9,7 @@
 namespace spix {
 namespace cmd {
 
-bool Command::canExecuteNow()
+bool Command::canExecuteNow(CommandEnvironment&)
 {
     return true;
 }

--- a/lib/src/Commands/Command.h
+++ b/lib/src/Commands/Command.h
@@ -18,7 +18,7 @@ public:
     virtual ~Command() = default;
 
     virtual void execute(CommandEnvironment& env) = 0;
-    virtual bool canExecuteNow();
+    virtual bool canExecuteNow(CommandEnvironment&);
 };
 
 } // namespace cmd

--- a/lib/src/Commands/CustomCmd.cpp
+++ b/lib/src/Commands/CustomCmd.cpp
@@ -20,7 +20,7 @@ void CustomCmd::execute(spix::CommandEnvironment& env)
     m_exec(env);
 }
 
-bool CustomCmd::canExecuteNow()
+bool CustomCmd::canExecuteNow(CommandEnvironment&)
 {
     return m_canExec();
 }

--- a/lib/src/Commands/CustomCmd.h
+++ b/lib/src/Commands/CustomCmd.h
@@ -23,7 +23,7 @@ public:
     CustomCmd(ExecFunction exec, CanExecFunction canExec);
 
     void execute(spix::CommandEnvironment&) override;
-    bool canExecuteNow() override;
+    bool canExecuteNow(CommandEnvironment&) override;
 
 private:
     ExecFunction m_exec;

--- a/lib/src/Commands/Wait.cpp
+++ b/lib/src/Commands/Wait.cpp
@@ -18,7 +18,7 @@ void Wait::execute(CommandEnvironment&)
 {
 }
 
-bool Wait::canExecuteNow()
+bool Wait::canExecuteNow(CommandEnvironment&)
 {
     if (!m_timerInitialized) {
         m_timerInitialized = true;

--- a/lib/src/Commands/Wait.h
+++ b/lib/src/Commands/Wait.h
@@ -18,7 +18,7 @@ public:
     Wait(std::chrono::milliseconds waitTime);
 
     void execute(CommandEnvironment&) override;
-    bool canExecuteNow() override;
+    bool canExecuteNow(CommandEnvironment&) override;
 
 private:
     bool m_timerInitialized = false;

--- a/lib/src/Commands/WaitForPath.cpp
+++ b/lib/src/Commands/WaitForPath.cpp
@@ -1,0 +1,46 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#include "WaitForPath.h"
+#include <QDebug>
+#include <Scene/Scene.h>
+
+namespace spix {
+namespace cmd {
+
+WaitForPath::WaitForPath(ItemPath path, std::chrono::milliseconds maxWaitTime, std::promise<bool> promise)
+: m_path(std::move(path))
+, m_promise(std::move(promise))
+, m_maxWaitTime(std::move(maxWaitTime))
+{
+}
+
+void WaitForPath::execute(CommandEnvironment& env)
+{
+    m_promise.set_value(m_itemFound);
+}
+
+bool WaitForPath::canExecuteNow(CommandEnvironment& env)
+{
+    if (!m_timerInitialized) {
+        m_timerInitialized = true;
+        m_startTime = std::chrono::steady_clock::now();
+        return false;
+    }
+
+    auto item = env.scene().itemAtPath(m_path);
+    qDebug() << "wait for path";
+    if (item) {
+        m_itemFound = item->visible();
+        return true;
+    }
+
+    auto timeSinceStart = std::chrono::steady_clock::now() - m_startTime;
+    return timeSinceStart >= m_maxWaitTime;
+}
+
+} // namespace cmd
+} // namespace spix

--- a/lib/src/Commands/WaitForPath.cpp
+++ b/lib/src/Commands/WaitForPath.cpp
@@ -32,7 +32,6 @@ bool WaitForPath::canExecuteNow(CommandEnvironment& env)
     }
 
     auto item = env.scene().itemAtPath(m_path);
-    qDebug() << "wait for path";
     if (item) {
         m_itemFound = item->visible();
         return true;

--- a/lib/src/Commands/WaitForPath.cpp
+++ b/lib/src/Commands/WaitForPath.cpp
@@ -5,7 +5,6 @@
  ****/
 
 #include "WaitForPath.h"
-#include <QDebug>
 #include <Scene/Scene.h>
 
 namespace spix {

--- a/lib/src/Commands/WaitForPath.h
+++ b/lib/src/Commands/WaitForPath.h
@@ -1,0 +1,35 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#pragma once
+
+#include "Command.h"
+#include <Spix/Data/ItemPath.h>
+
+#include <chrono>
+#include <future>
+
+namespace spix {
+namespace cmd {
+
+class WaitForPath : public Command {
+public:
+    WaitForPath(ItemPath path, std::chrono::milliseconds maxWaitTime, std::promise<bool> promise);
+
+    void execute(CommandEnvironment&) override;
+    bool canExecuteNow(CommandEnvironment&) override;
+
+private:
+    bool m_timerInitialized = false;
+    std::chrono::steady_clock::time_point m_startTime;
+    std::chrono::milliseconds m_maxWaitTime;
+    ItemPath m_path;
+    std::promise<bool> m_promise;
+    bool m_itemFound = false;
+};
+
+} // namespace cmd
+} // namespace spix

--- a/lib/src/TestServer.cpp
+++ b/lib/src/TestServer.cpp
@@ -24,6 +24,7 @@
 #include <Commands/Screenshot.h>
 #include <Commands/SetProperty.h>
 #include <Commands/Wait.h>
+#include <Commands/WaitForPath.h>
 
 #include <Spix/Events/Identifiers.h>
 
@@ -155,6 +156,16 @@ std::vector<std::string> TestServer::getErrors()
     std::promise<std::vector<std::string>> promise;
     auto result = promise.get_future();
     auto cmd = std::make_unique<cmd::GetTestStatus>(true, std::move(promise));
+    m_cmdExec->enqueueCommand(std::move(cmd));
+
+    return result.get();
+}
+
+bool TestServer::waitForPath(ItemPath path, std::chrono::milliseconds maxWaitTime)
+{
+    std::promise<bool> promise;
+    auto result = promise.get_future();
+    auto cmd = std::make_unique<cmd::WaitForPath>(path, maxWaitTime, std::move(promise));
     m_cmdExec->enqueueCommand(std::move(cmd));
 
     return result.get();


### PR DESCRIPTION
I added a function to wait for a path. 
It is useful when you click on a UI, and have to wait for an Element. 


Can be used: 
```python
from xmlrpc.client import ServerProxy

session = ServerProxy('http://localhost:9000')
session.mouseClick('mainWindow/buttonImage')
session.waitForPath('mainWindow/theTitle', 400)
```

The first parameter is the path that is waited for. 
The second is the timeout for the waiting.