### PR TITLE
Rename WaitForPath to WaitForItem

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,8 +66,8 @@ set(SOURCES
     src/Commands/SetProperty.h
     src/Commands/Wait.cpp
     src/Commands/Wait.h
-    src/Commands/WaitForPath.cpp
-    src/Commands/WaitForPath.h
+    src/Commands/WaitForItem.cpp
+    src/Commands/WaitForItem.h
 
     src/CommandExecuter/CommandEnvironment.cpp
     src/CommandExecuter/CommandEnvironment.h

--- a/lib/include/Spix/TestServer.h
+++ b/lib/include/Spix/TestServer.h
@@ -66,7 +66,7 @@ public:
     Rect getBoundingBox(ItemPath path);
     bool existsAndVisible(ItemPath path);
     std::vector<std::string> getErrors();
-    bool waitForPath(ItemPath path, std::chrono::milliseconds maxWaitTime);
+    bool waitForItem(ItemPath path, std::chrono::milliseconds maxWaitTime);
 
     void takeScreenshot(ItemPath targetItem, std::string filePath);
     std::string takeScreenshotAsBase64(ItemPath targetItem);

--- a/lib/src/AnyRpcServer.cpp
+++ b/lib/src/AnyRpcServer.cpp
@@ -108,10 +108,10 @@ AnyRpcServer::AnyRpcServer(int anyrpcPort)
         "Returns true if the given object exists | existsAndVisible(string path) : bool exists_and_visible",
         [this](std::string path) { return existsAndVisible(std::move(path)); });
 
-    utils::AddFunctionToAnyRpc<bool(std::string, int)>(methodManager, "waitForPath",
-        "Returns true if the given object exists and the time is not expired | waitForPath(string path, int "
+    utils::AddFunctionToAnyRpc<bool(std::string, int)>(methodManager, "waitForItem",
+        "Returns true if the given object exists and the time is not expired | waitForItem(string path, int "
         "millisecondsToWait) : bool exists_and_visible",
-        [this](std::string path, int ms) { return waitForPath(std::move(path), std::chrono::milliseconds(ms)); });
+        [this](std::string path, int ms) { return waitForItem(std::move(path), std::chrono::milliseconds(ms)); });
 
     utils::AddFunctionToAnyRpc<std::vector<std::string>()>(methodManager, "getErrors",
         "Returns internal errors that occurred during test execution | getErrors() : (strings) [error1, ...]",

--- a/lib/src/Commands/WaitForItem.cpp
+++ b/lib/src/Commands/WaitForItem.cpp
@@ -4,25 +4,25 @@
  * See LICENSE.txt file in the project root for full license information.
  ****/
 
-#include "WaitForPath.h"
+#include "WaitForItem.h"
 #include <Scene/Scene.h>
 
 namespace spix {
 namespace cmd {
 
-WaitForPath::WaitForPath(ItemPath path, std::chrono::milliseconds maxWaitTime, std::promise<bool> promise)
+WaitForItem::WaitForItem(ItemPath path, std::chrono::milliseconds maxWaitTime, std::promise<bool> promise)
 : m_path(std::move(path))
 , m_promise(std::move(promise))
 , m_maxWaitTime(std::move(maxWaitTime))
 {
 }
 
-void WaitForPath::execute(CommandEnvironment& env)
+void WaitForItem::execute(CommandEnvironment& env)
 {
     m_promise.set_value(m_itemFound);
 }
 
-bool WaitForPath::canExecuteNow(CommandEnvironment& env)
+bool WaitForItem::canExecuteNow(CommandEnvironment& env)
 {
     if (!m_timerInitialized) {
         m_timerInitialized = true;

--- a/lib/src/Commands/WaitForItem.h
+++ b/lib/src/Commands/WaitForItem.h
@@ -15,9 +15,9 @@
 namespace spix {
 namespace cmd {
 
-class WaitForPath : public Command {
+class WaitForItem : public Command {
 public:
-    WaitForPath(ItemPath path, std::chrono::milliseconds maxWaitTime, std::promise<bool> promise);
+    WaitForItem(ItemPath path, std::chrono::milliseconds maxWaitTime, std::promise<bool> promise);
 
     void execute(CommandEnvironment&) override;
     bool canExecuteNow(CommandEnvironment&) override;

--- a/lib/src/TestServer.cpp
+++ b/lib/src/TestServer.cpp
@@ -25,7 +25,7 @@
 #include <Commands/ScreenshotBase64.h>
 #include <Commands/SetProperty.h>
 #include <Commands/Wait.h>
-#include <Commands/WaitForPath.h>
+#include <Commands/WaitForItem.h>
 
 #include <Spix/Events/Identifiers.h>
 
@@ -174,11 +174,11 @@ std::vector<std::string> TestServer::getErrors()
     return result.get();
 }
 
-bool TestServer::waitForPath(ItemPath path, std::chrono::milliseconds maxWaitTime)
+bool TestServer::waitForItem(ItemPath path, std::chrono::milliseconds maxWaitTime)
 {
     std::promise<bool> promise;
     auto result = promise.get_future();
-    auto cmd = std::make_unique<cmd::WaitForPath>(path, maxWaitTime, std::move(promise));
+    auto cmd = std::make_unique<cmd::WaitForItem>(path, maxWaitTime, std::move(promise));
     m_cmdExec->enqueueCommand(std::move(cmd));
 
     return result.get();


### PR DESCRIPTION
This PR renames the recently added command from "WaitForPath" to WaitForItem", as it is waiting for an item at a path, but not for the path itself.