### PR TITLE
support escaped slash in item paths

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -104,6 +104,7 @@ set(SOURCES
     src/Utils/AnyRpcFunction.h
     src/Utils/DebugDump.cpp
     src/Utils/DebugDump.h
+    src/Utils/PathParser.cpp
     src/Utils/QtEventRecorder.cpp
     src/Utils/QtEventRecorder.h
 )

--- a/lib/src/Data/ItemPath.cpp
+++ b/lib/src/Data/ItemPath.cpp
@@ -5,9 +5,9 @@
  ****/
 
 #include <Spix/Data/ItemPath.h>
+#include <Utils/PathParser.h>
 
 #include <iterator>
-#include <sstream>
 
 namespace spix {
 
@@ -19,16 +19,8 @@ ItemPath::ItemPath(const char* path)
 }
 
 ItemPath::ItemPath(const std::string& path)
+: m_components(utils::ParsePathString(path))
 {
-    std::stringstream pathss(path);
-
-    while (pathss) {
-        std::string component;
-        getline(pathss, component, '/');
-        if (component.length() > 0) {
-            m_components.push_back(std::move(component));
-        }
-    }
 }
 
 ItemPath::ItemPath(std::vector<std::string> components)
@@ -48,16 +40,7 @@ std::string ItemPath::rootComponent() const
 
 std::string ItemPath::string() const
 {
-    std::string path;
-
-    for (auto& component : m_components) {
-        if (!path.empty()) {
-            path += "/";
-        }
-        path += component;
-    }
-
-    return path;
+    return utils::FormatPathString(m_components);
 }
 
 ItemPath ItemPath::subPath(size_t offset) const

--- a/lib/src/Utils/PathParser.cpp
+++ b/lib/src/Utils/PathParser.cpp
@@ -1,0 +1,81 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#include <Utils/PathParser.h>
+
+namespace spix {
+namespace utils {
+
+std::vector<std::string> ParsePathString(const std::string& path)
+{
+    std::vector<std::string> components;
+    std::string currentComponent;
+    bool escapeNext = false;
+
+    for (size_t i = 0; i < path.length(); ++i) {
+        char c = path[i];
+
+        if (escapeNext) {
+            // If we're escaping this character, add it to the component regardless of what it is
+            currentComponent += c;
+            escapeNext = false;
+        } else if (c == '\\') {
+            // Backslash, set flag to escape the next character
+            escapeNext = true;
+        } else if (c == '/') {
+            // Forward slash, save current component if not empty
+            if (!currentComponent.empty()) {
+                components.push_back(std::move(currentComponent));
+                currentComponent.clear();
+            }
+        } else {
+            // Regular character, add to current component
+            currentComponent += c;
+        }
+    }
+
+    // Add the last component if not empty
+    if (!currentComponent.empty()) {
+        components.push_back(std::move(currentComponent));
+    }
+
+    return components;
+}
+
+std::string FormatPathString(const std::vector<std::string>& components)
+{
+    std::string path;
+
+    for (const auto& component : components) {
+        if (!path.empty()) {
+            path += '/';
+        }
+
+        // Escape any forward slashes and backslashes in the component value
+        std::string escapedValue = component;
+
+        // First, escape all backslashes by replacing \ with \\.
+        size_t pos = 0;
+        while ((pos = escapedValue.find('\\', pos)) != std::string::npos) {
+            escapedValue.insert(pos, "\\");
+            pos += 2; // Skip over the two backslashes
+        }
+
+        // Then, escape all forward slashes by replacing / with \/
+        pos = 0;
+        while ((pos = escapedValue.find('/', pos)) != std::string::npos) {
+            escapedValue.insert(pos, "\\");
+            pos += 2; // Skip over the backslash and forward slash
+        }
+
+        path += escapedValue;
+    }
+
+    return path;
+}
+
+} // namespace utils
+} // namespace spix

--- a/lib/src/Utils/PathParser.h
+++ b/lib/src/Utils/PathParser.h
@@ -1,0 +1,32 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace spix {
+namespace utils {
+
+/**
+ * Parses a path string into its component parts, handling escaped characters.
+ *
+ * @param path The path string to parse (e.g., "window/item/subitem")
+ * @return A vector of component strings with any escaped characters processed
+ */
+std::vector<std::string> ParsePathString(const std::string& path);
+
+/**
+ * Formats a vector of component strings into a properly escaped path string.
+ *
+ * @param components A vector of component strings
+ * @return A formatted path string with proper escaping of special characters
+ */
+std::string FormatPathString(const std::vector<std::string>& components);
+
+} // namespace utils
+} // namespace spix

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_SOURCES
 
     unittests/Utils/AnyRpcFunction_test.cpp
     unittests/Utils/AnyRpcUtils_test.cpp
+    unittests/Utils/PathParser_test.cpp
 )
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX source FILES ${TEST_SOURCES})

--- a/lib/tests/unittests/Utils/PathParser_test.cpp
+++ b/lib/tests/unittests/Utils/PathParser_test.cpp
@@ -1,0 +1,168 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#include <gtest/gtest.h>
+
+#include <Utils/PathParser.h>
+#include <string>
+#include <vector>
+
+TEST(PathParserTest, ParsePathString_Basic)
+{
+    // Basic path parsing
+    std::vector<std::string> components = spix::utils::ParsePathString("window/item/subitem");
+
+    EXPECT_EQ(components.size(), 3);
+    EXPECT_EQ(components.at(0), "window");
+    EXPECT_EQ(components.at(1), "item");
+    EXPECT_EQ(components.at(2), "subitem");
+}
+
+TEST(PathParserTest, ParsePathString_Empty)
+{
+    // Empty path
+    std::vector<std::string> empty_components = spix::utils::ParsePathString("");
+    EXPECT_EQ(empty_components.size(), 0);
+
+    // Path with just slashes
+    std::vector<std::string> slash_components = spix::utils::ParsePathString("///");
+    EXPECT_EQ(slash_components.size(), 0);
+}
+
+TEST(PathParserTest, ParsePathString_ExtraSlashes)
+{
+    // Path with extra slashes
+    std::vector<std::string> components = spix::utils::ParsePathString("/windowname/item/subitem/");
+
+    EXPECT_EQ(components.size(), 3);
+    EXPECT_EQ(components.at(0), "windowname");
+    EXPECT_EQ(components.at(1), "item");
+    EXPECT_EQ(components.at(2), "subitem");
+}
+
+TEST(PathParserTest, ParsePathString_EscapedSlashes)
+{
+    // Test path with escaped slashes
+    std::vector<std::string> components = spix::utils::ParsePathString("window\\/name/item/sub\\/item");
+
+    EXPECT_EQ(components.size(), 3);
+    EXPECT_EQ(components.at(0), "window/name");
+    EXPECT_EQ(components.at(1), "item");
+    EXPECT_EQ(components.at(2), "sub/item");
+
+    // Path with only escaped content
+    std::vector<std::string> escaped_only = spix::utils::ParsePathString("\\/\\/");
+    EXPECT_EQ(escaped_only.size(), 1);
+    EXPECT_EQ(escaped_only.at(0), "//");
+
+    // Complex path with multiple escaped slashes
+    std::vector<std::string> complex = spix::utils::ParsePathString("a\\/b\\/c/d/e\\/f\\/g");
+    EXPECT_EQ(complex.size(), 3);
+    EXPECT_EQ(complex.at(0), "a/b/c");
+    EXPECT_EQ(complex.at(1), "d");
+    EXPECT_EQ(complex.at(2), "e/f/g");
+}
+
+TEST(PathParserTest, ParsePathString_Backslashes)
+{
+    // Test how backslashes are handled
+
+    // 1. A single backslash that escapes a normal character (should remove the backslash)
+    std::vector<std::string> components1 = spix::utils::ParsePathString("window\\name/item");
+    EXPECT_EQ(components1.size(), 2);
+    EXPECT_EQ(components1.at(0), "windowname"); // Backslash should be removed
+    EXPECT_EQ(components1.at(1), "item");
+
+    // 2. A double backslash (escaping a backslash)
+    std::vector<std::string> components2 = spix::utils::ParsePathString("window\\\\name/item");
+    EXPECT_EQ(components2.size(), 2);
+    EXPECT_EQ(components2.at(0), "window\\name"); // Should contain one backslash
+    EXPECT_EQ(components2.at(1), "item");
+
+    // 3. A backslash at the end of a component (should be preserved)
+    std::vector<std::string> components3 = spix::utils::ParsePathString("window\\/item\\\\/"); // "window/item\"/"
+    EXPECT_EQ(components3.size(), 1);
+    EXPECT_EQ(components3.at(0), "window/item\\"); // Should contain a slash and a backslash
+
+    // 4. A trailing backslash in the path string
+    std::vector<std::string> components4 = spix::utils::ParsePathString("component\\");
+    EXPECT_EQ(components4.size(), 1);
+    EXPECT_EQ(components4.at(0), "component");
+}
+
+TEST(PathParserTest, FormatPathString_Basic)
+{
+    // Basic path formatting
+    std::vector<std::string> components = {"window", "item", "subitem"};
+    std::string path = spix::utils::FormatPathString(components);
+
+    EXPECT_EQ(path, "window/item/subitem");
+}
+
+TEST(PathParserTest, FormatPathString_Empty)
+{
+    // Empty components
+    std::vector<std::string> empty_components;
+    std::string empty_path = spix::utils::FormatPathString(empty_components);
+
+    EXPECT_EQ(empty_path, "");
+
+    // Single empty component
+    std::vector<std::string> single_empty = {""};
+    std::string single_empty_path = spix::utils::FormatPathString(single_empty);
+
+    EXPECT_EQ(single_empty_path, "");
+}
+
+TEST(PathParserTest, FormatPathString_EscapedSlashes)
+{
+    // Components with slashes that need escaping
+    std::vector<std::string> components = {"window/name", "item", "sub/item"};
+    std::string path = spix::utils::FormatPathString(components);
+
+    EXPECT_EQ(path, "window\\/name/item/sub\\/item");
+}
+
+TEST(PathParserTest, FormatPathString_Backslashes)
+{
+    // Components with backslashes that need escaping
+    std::vector<std::string> components = {"back\\slash", "item", "sub\\item"};
+    std::string path = spix::utils::FormatPathString(components);
+
+    EXPECT_EQ(path, "back\\\\slash/item/sub\\\\item");
+
+    // Complex component with both backslashes and forward slashes
+    std::vector<std::string> complex = {"a/b\\c", "d", "e\\f/g"};
+    std::string complex_path = spix::utils::FormatPathString(complex);
+
+    EXPECT_EQ(complex_path, "a\\/b\\\\c/d/e\\\\f\\/g");
+}
+
+TEST(PathParserTest, RoundTrip)
+{
+    // Test that parsing and then formatting produces the same result
+
+    // 1. Simple path
+    std::string original1 = "window/item/subitem";
+    std::vector<std::string> components1 = spix::utils::ParsePathString(original1);
+    std::string formatted1 = spix::utils::FormatPathString(components1);
+    EXPECT_EQ(formatted1, original1);
+
+    // 2. Path with escaped characters
+    std::string original2 = "window\\/name/item\\\\name/sub\\/item";
+    std::vector<std::string> components2 = spix::utils::ParsePathString(original2);
+    std::string formatted2 = spix::utils::FormatPathString(components2);
+    EXPECT_EQ(formatted2, original2);
+
+    // 3. Idempotence: formatting then parsing then formatting again
+    std::vector<std::string> original_components = {"window/item", "sub\\item"};
+    std::string path = spix::utils::FormatPathString(original_components);
+    std::vector<std::string> parsed_components = spix::utils::ParsePathString(path);
+    std::string reforced_path = spix::utils::FormatPathString(parsed_components);
+
+    EXPECT_EQ(parsed_components, original_components);
+    EXPECT_EQ(reforced_path, path);
+}


### PR DESCRIPTION
This PR introduces support for escaped slashes in item paths. This means that spix can now find an object that has a slash in its name (e.g. "item_1/2")

In a Path, this would be formatted as "mainWindow/subView/item_1\/2"

To structure things a little better, the actual parsing of the path was moved to PathParser.cpp