### PR TITLE
Introduce Path Selectors

### DIFF
--- a/examples/GTest/main.cpp
+++ b/examples/GTest/main.cpp
@@ -72,6 +72,14 @@ TEST(GTestExample, BasicUITest)
     srv->mouseClick(spix::ItemPath("mainWindow/Button_2"), spix::MouseButtons::Left,
         spix::KeyModifiers::Shift | spix::KeyModifiers::Control);
     srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick(spix::ItemPath("mainWindow/propItem/.propertyWithTarget"));
+    srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick(spix::ItemPath("mainWindow/.propertyWithTarget"));
+    srv->wait(std::chrono::milliseconds(500));
+    srv->mouseClick(spix::ItemPath("mainWindow/.propertyWithParent/Button_2"));
+    srv->wait(std::chrono::milliseconds(500));
+
+    srv->wait(std::chrono::milliseconds(500));
 
     auto result = srv->getStringProperty("mainWindow/results", "text");
 
@@ -84,9 +92,14 @@ Button 1 clicked
 Button 1 right clicked
 Button 2 shift clicked
 Button 2 control clicked
-Button 2 shift control clicked)RSLT";
+Button 2 shift control clicked
+Button 1 clicked
+Button 1 clicked
+Button 2 clicked)RSLT";
 
     EXPECT_EQ(result, expected_result);
+
+    EXPECT_EQ(srv->getErrors(), std::vector<std::string> {});
 
     srv->quit();
 }

--- a/examples/GTest/main.qml
+++ b/examples/GTest/main.qml
@@ -22,6 +22,7 @@ Window {
 
         Button {
             objectName: "Button_1"
+            id: button1
             text: "Press Me"
 			MouseArea {
 				anchors.fill: parent
@@ -73,5 +74,12 @@ Window {
             right: parent.right
             bottom: parent.bottom
         }
+    }
+
+    Item {
+        id: propItem
+        objectName: "propItem"
+        property var propertyWithTarget: button1
+        property var propertyWithParent: button1.parent
     }
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SOURCES
 
     src/Data/Geometry.cpp
     src/Data/ItemPath.cpp
+    src/Data/ItemPathComponent.cpp
     src/Data/ItemPosition.cpp
     src/Data/PasteboardContent.cpp
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -90,6 +90,8 @@ set(SOURCES
     src/Scene/Mock/MockScene.h
     src/Scene/Mock/MockItem.cpp
     src/Scene/Mock/MockItem.h
+    src/Scene/Qt/FindQtItem.cpp
+    src/Scene/Qt/FindQtItem.h
     src/Scene/Qt/QtEvents.cpp
     src/Scene/Qt/QtEvents.h
     src/Scene/Qt/QtItem.cpp

--- a/lib/include/Spix/Data/ItemPath.h
+++ b/lib/include/Spix/Data/ItemPath.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include <Spix/Data/ItemPathComponent.h>
 #include <Spix/spix_export.h>
 
 namespace spix {
@@ -33,18 +34,18 @@ public:
     ItemPath();
     ItemPath(const char* path);
     ItemPath(const std::string& path);
-    ItemPath(std::vector<std::string> components);
+    ItemPath(std::vector<path::Component> components);
 
-    const std::vector<std::string>& components() const;
+    const std::vector<path::Component>& components() const;
     size_t length() const { return m_components.size(); };
-    std::string rootComponent() const;
+    const path::Component& rootComponent() const;
 
     std::string string() const;
 
     ItemPath subPath(size_t offset) const;
 
 private:
-    std::vector<std::string> m_components;
+    std::vector<path::Component> m_components;
 };
 
 } // namespace spix

--- a/lib/include/Spix/Data/ItemPathComponent.h
+++ b/lib/include/Spix/Data/ItemPathComponent.h
@@ -6,9 +6,10 @@
 
 #pragma once
 
+#include <Spix/spix_export.h>
+
 #include <string>
 #include <variant>
-#include <Spix/spix_export.h>
 
 namespace spix {
 namespace path {
@@ -60,4 +61,4 @@ private:
 };
 
 } // namespace path
-} // namespace spix 
+} // namespace spix

--- a/lib/include/Spix/Data/ItemPathComponent.h
+++ b/lib/include/Spix/Data/ItemPathComponent.h
@@ -1,0 +1,63 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#pragma once
+
+#include <string>
+#include <variant>
+#include <Spix/spix_export.h>
+
+namespace spix {
+namespace path {
+
+/**
+ * @brief Selector for item path by name
+ */
+class SPIX_EXPORT NameSelector {
+public:
+    NameSelector() = default;
+    explicit NameSelector(std::string name);
+
+    const std::string& name() const;
+
+private:
+    std::string m_name;
+};
+
+/**
+ * @brief Selector for item path by property (starting with '.')
+ */
+class SPIX_EXPORT PropertySelector {
+public:
+    PropertySelector() = default;
+    explicit PropertySelector(std::string name);
+
+    const std::string& name() const;
+
+private:
+    std::string m_name;
+};
+
+using Selector = std::variant<NameSelector, PropertySelector>;
+
+/**
+ * @brief A component of an item path
+ */
+class SPIX_EXPORT Component {
+public:
+    Component() = default;
+    explicit Component(const std::string& rawValue);
+    explicit Component(Selector selector);
+
+    std::string string() const;
+    const Selector& selector() const;
+
+private:
+    Selector m_selector;
+};
+
+} // namespace path
+} // namespace spix 

--- a/lib/src/Data/ItemPath.cpp
+++ b/lib/src/Data/ItemPath.cpp
@@ -19,28 +19,35 @@ ItemPath::ItemPath(const char* path)
 }
 
 ItemPath::ItemPath(const std::string& path)
-: m_components(utils::ParsePathString(path))
 {
+    auto stringComponents = utils::ParsePathString(path);
+    for (const auto& component : stringComponents) {
+        m_components.emplace_back(path::Component(component));
+    }
 }
 
-ItemPath::ItemPath(std::vector<std::string> components)
+ItemPath::ItemPath(std::vector<path::Component> components)
 : m_components(std::move(components))
 {
 }
 
-const std::vector<std::string>& ItemPath::components() const
+const std::vector<path::Component>& ItemPath::components() const
 {
     return m_components;
 }
 
-std::string ItemPath::rootComponent() const
+const path::Component& ItemPath::rootComponent() const
 {
     return m_components.at(0);
 }
 
 std::string ItemPath::string() const
 {
-    return utils::FormatPathString(m_components);
+    std::vector<std::string> stringComponents;
+    for (const auto& component : m_components) {
+        stringComponents.emplace_back(component.string());
+    }
+    return utils::FormatPathString(stringComponents);
 }
 
 ItemPath ItemPath::subPath(size_t offset) const
@@ -49,7 +56,7 @@ ItemPath ItemPath::subPath(size_t offset) const
         return ItemPath();
     }
 
-    std::vector<std::string> sub_components;
+    std::vector<path::Component> sub_components;
     std::copy(m_components.begin() + offset, m_components.end(), std::back_inserter(sub_components));
     return ItemPath(std::move(sub_components));
 }

--- a/lib/src/Data/ItemPathComponent.cpp
+++ b/lib/src/Data/ItemPathComponent.cpp
@@ -1,0 +1,68 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#include <Spix/Data/ItemPathComponent.h>
+#include <variant>
+
+namespace spix {
+namespace path {
+
+// NameSelector implementation
+NameSelector::NameSelector(std::string name)
+: m_name(std::move(name))
+{
+}
+
+const std::string& NameSelector::name() const
+{
+    return m_name;
+}
+
+// PropertySelector implementation
+PropertySelector::PropertySelector(std::string name)
+: m_name(std::move(name))
+{
+}
+
+const std::string& PropertySelector::name() const
+{
+    return m_name;
+}
+
+// Component implementation
+Component::Component(const std::string& rawValue)
+{
+    // If the raw value starts with '.', create a property selector
+    if (!rawValue.empty() && rawValue[0] == '.') {
+        std::string propertyName = rawValue.substr(1); // Remove the leading '.'
+        m_selector = PropertySelector(propertyName);
+    } else {
+        m_selector = NameSelector(rawValue);
+    }
+}
+
+Component::Component(Selector selector)
+: m_selector(std::move(selector))
+{
+}
+
+std::string Component::string() const
+{
+    if (std::holds_alternative<NameSelector>(m_selector)) {
+        return std::get<NameSelector>(m_selector).name();
+    } else if (std::holds_alternative<PropertySelector>(m_selector)) {
+        return "." + std::get<PropertySelector>(m_selector).name();
+    }
+    return "";
+}
+
+const Selector& Component::selector() const
+{
+    return m_selector;
+}
+
+} // namespace path
+} // namespace spix 

--- a/lib/src/Data/ItemPathComponent.cpp
+++ b/lib/src/Data/ItemPathComponent.cpp
@@ -65,4 +65,4 @@ const Selector& Component::selector() const
 }
 
 } // namespace path
-} // namespace spix 
+} // namespace spix

--- a/lib/src/Scene/Qt/FindQtItem.cpp
+++ b/lib/src/Scene/Qt/FindQtItem.cpp
@@ -1,0 +1,163 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#include "FindQtItem.h"
+#include <Scene/Qt/QtItemTools.h>
+
+#include <QGuiApplication>
+#include <QQuickWindow>
+#include <QQuickItem>
+
+namespace {
+
+QObject* MatchesSelector(QObject* item, const spix::path::Selector& selector)
+{
+    return std::visit(
+        [item](const auto& specific_selector) -> QObject* {
+            using SelectorType = std::decay_t<decltype(specific_selector)>;
+
+            if constexpr (std::is_same_v<SelectorType, spix::path::NameSelector>) {
+                const auto& itemName = specific_selector.name();
+                if (spix::qt::GetObjectName(item) == QString::fromStdString(itemName)) {
+                    return item;
+                }
+                return nullptr;
+            } else if constexpr (std::is_same_v<SelectorType, spix::path::PropertySelector>) {
+                if (!item) {
+                    return nullptr;
+                }
+                const auto& propertyName = specific_selector.name();
+                QVariant propertyValue = item->property(propertyName.c_str());
+                
+                if (!propertyValue.isValid()) {
+                    return nullptr;
+                }
+                
+                return propertyValue.value<QObject*>();
+            } else {
+                return nullptr; // Unknown selector type
+            }
+        },
+        selector);
+}
+
+/**
+ * Performs a DFS to find the first matching item in the UI tree.
+ *
+ * @param pathComponents Vector of path components to match
+ * @param currentNode Starting node for the search
+ * @param matchedCount Number of path components already matched in the ancestor chain
+ * @return The first matching QQuickItem or nullptr if none found
+ */
+QQuickItem* FindMatchingItem(
+    const std::vector<spix::path::Component>& pathComponents, QObject* currentNode, size_t matchedCount)
+{
+    if (!currentNode) {
+        return nullptr;
+    }
+    if (matchedCount >= pathComponents.size()) {
+        return nullptr;
+    }
+
+    // If we have a potential match, check if this node matches the next component
+    const auto& component = pathComponents[matchedCount];
+    const auto& selector = component.selector();
+
+    // Check if this node matches the current selector
+    QObject* matchedObject = MatchesSelector(currentNode, selector);
+    if (matchedObject) {
+        // Increment matched count as we found a match
+        matchedCount++;
+        
+        // If we've matched all components, return this item if it's a QQuickItem
+        if (matchedCount == pathComponents.size()) {
+            return qobject_cast<QQuickItem*>(matchedObject);
+        }
+        
+        // Continue searching in the matched object's hierarchy
+        // if it is different from the current node or if the next component is a property selector,
+        // as a property selector might reference a property of the current node
+        const auto& nextComponent = pathComponents[matchedCount];
+        if (matchedObject != currentNode || std::holds_alternative<spix::path::PropertySelector>(nextComponent.selector())) {
+            return FindMatchingItem(pathComponents, matchedObject, matchedCount);
+        }
+    }
+
+    // Continue DFS through children
+    QQuickItem* result = nullptr;
+
+    // Use ForEachChild to iterate through all children, with special handling for repeaters
+    spix::qt::ForEachChild(currentNode, [&](QObject* child) -> bool {
+        if ((result = FindMatchingItem(pathComponents, child, matchedCount))) {
+            return false; // Stop iteration if we found a match
+        }
+        return true; // Continue iteration
+    });
+
+    return result; // Will return nullptr if no match was found
+}
+
+/**
+ * Find a QQuickWindow by its name
+ * @param name The name of the window to find
+ * @return The window if found, nullptr otherwise
+ */
+QQuickWindow* GetQQuickWindowWithName(const std::string& name)
+{
+    QString qtName = QString::fromStdString(name);
+    QQuickWindow* foundWindow = nullptr;
+
+    auto windows = QGuiApplication::topLevelWindows();
+    for (const auto& window : windows) {
+        QQuickWindow* qquickWindow = qobject_cast<QQuickWindow*>(window);
+        if (qquickWindow && (spix::qt::GetObjectName(qquickWindow) == qtName)) {
+            foundWindow = qquickWindow;
+            break;
+        }
+    }
+
+    return foundWindow;
+}
+
+} // namespace
+
+namespace spix {
+namespace qt {
+
+QQuickItem* GetQQuickItemAtPath(const spix::ItemPath& path)
+{
+    if (path.length() == 0) {
+        return nullptr;
+    }
+
+    // First find the window
+    const auto& windowComponent = path.rootComponent();
+    const auto& windowSelector = windowComponent.selector();
+
+    if (!std::holds_alternative<spix::path::NameSelector>(windowSelector)) {
+        return nullptr;
+    }
+
+    const auto& windowName = std::get<spix::path::NameSelector>(windowSelector).name();
+    QQuickWindow* window = GetQQuickWindowWithName(windowName);
+
+    if (!window) {
+        return nullptr;
+    }
+
+    // If path only has window component, return window's contentItem
+    if (path.length() == 1) {
+        return window->contentItem();
+    }
+
+    // Start DFS from window's contentItem to find the item
+    // Skip the window component (index 0) and start matching from the first child component
+    auto components = path.components();
+    return FindMatchingItem(components, window->contentItem(), 1);
+}
+
+} // namespace qt
+} // namespace spix 

--- a/lib/src/Scene/Qt/FindQtItem.h
+++ b/lib/src/Scene/Qt/FindQtItem.h
@@ -1,0 +1,24 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#pragma once
+
+#include <Spix/Data/ItemPath.h>
+#include <QQuickItem>
+#include <QQuickWindow>
+
+namespace spix {
+namespace qt {
+
+/**
+ * Find a QQuickItem at the specified item path
+ * @param path The item path to search for
+ * @return The item if found, nullptr otherwise
+ */
+QQuickItem* GetQQuickItemAtPath(const spix::ItemPath& path);
+
+} // namespace qt
+} // namespace spix 

--- a/lib/src/Scene/Qt/FindQtItem.h
+++ b/lib/src/Scene/Qt/FindQtItem.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Spix/Data/ItemPath.h>
+
 #include <QQuickItem>
 #include <QQuickWindow>
 
@@ -21,4 +22,4 @@ namespace qt {
 QQuickItem* GetQQuickItemAtPath(const spix::ItemPath& path);
 
 } // namespace qt
-} // namespace spix 
+} // namespace spix

--- a/lib/src/Scene/Qt/QtItemTools.cpp
+++ b/lib/src/Scene/Qt/QtItemTools.cpp
@@ -51,12 +51,12 @@ void ForEachChild(QObject* object, const std::function<bool(QObject*)>& callback
     if (!object) {
         return;
     }
-    
+
     // Special handling for QQuickRepeater objects
     auto rootClassName = object->metaObject()->className();
     if (rootClassName == repeater_class_name) {
         QQuickItem* repeaterItem = static_cast<QQuickItem*>(object);
-        
+
         // Iterate through repeater's generated items
         int index = 0;
         QQuickItem* child = nullptr;
@@ -66,7 +66,7 @@ void ForEachChild(QObject* object, const std::function<bool(QObject*)>& callback
             }
         }
     }
-    
+
     // Handle QQuickItems and their childItems()
     if (auto quickItem = qobject_cast<QQuickItem*>(object)) {
         for (auto* childItem : quickItem->childItems()) {

--- a/lib/src/Scene/Qt/QtItemTools.h
+++ b/lib/src/Scene/Qt/QtItemTools.h
@@ -29,12 +29,12 @@ QString GetObjectName(QObject* object);
 
 /**
  * @brief Iterates over all children of a QObject, with special handling for QQuickItems and Repeaters
- * 
+ *
  * This function handles the different ways children are accessed in Qt:
  * - For QQuickItems, it uses childItems() instead of children()
  * - For QQuickRepeaters, it iterates through its generated items
  * - For regular QObjects, it uses the children() list
- * 
+ *
  * @param object The parent object whose children to iterate over
  * @param callback A function to call for each child, should return true to continue iteration or false to stop
  */

--- a/lib/src/Scene/Qt/QtItemTools.h
+++ b/lib/src/Scene/Qt/QtItemTools.h
@@ -13,6 +13,8 @@
 #include <QQuickItem>
 #include <QVariant>
 
+#include <functional>
+
 class QString;
 
 namespace spix {
@@ -22,24 +24,21 @@ extern const QString repeater_class_name;
 extern const char* item_at_method_name;
 
 QQuickItem* RepeaterChildAtIndex(QQuickItem* repeater, int index);
-QQuickItem* RepeaterChildWithName(QQuickItem* repeater, const QString& name);
 
 QString GetObjectName(QObject* object);
 
 /**
- * @brief Find a child object with the given name.
- *
- * This works similar to `QObject::findChild`. However, once it
- * encounters a `QQuickItem`, it no longer iterates over the object's
- * `children()`, but rather its `childItems()`.
+ * @brief Iterates over all children of a QObject, with special handling for QQuickItems and Repeaters
+ * 
+ * This function handles the different ways children are accessed in Qt:
+ * - For QQuickItems, it uses childItems() instead of children()
+ * - For QQuickRepeaters, it iterates through its generated items
+ * - For regular QObjects, it uses the children() list
+ * 
+ * @param object The parent object whose children to iterate over
+ * @param callback A function to call for each child, should return true to continue iteration or false to stop
  */
-QObject* FindChildItem(QObject* object, const QString& name);
-
-template <typename T>
-T FindChildItem(QObject* object, const QString& name)
-{
-    return qobject_cast<T>(FindChildItem(object, name));
-}
+void ForEachChild(QObject* object, const std::function<bool(QObject*)>& callback);
 
 using QMLReturnVariant = std::variant<std::nullptr_t, bool, int, float, double, QString, QDateTime, QVariant>;
 QGenericReturnArgument GetReturnArgForQMetaType(int type, QMLReturnVariant& toInitialize);

--- a/lib/src/Scene/Qt/QtScene.cpp
+++ b/lib/src/Scene/Qt/QtScene.cpp
@@ -5,6 +5,7 @@
  ****/
 
 #include "QtScene.h"
+#include "FindQtItem.h"
 
 #include <Scene/Qt/QtItem.h>
 #include <Scene/Qt/QtItemTools.h>
@@ -17,170 +18,13 @@
 #include <QQuickItem>
 #include <QQuickWindow>
 
-namespace {
-
-QQuickWindow* GetQQuickWindowWithName(const std::string& name)
-{
-    QString qtName = QString::fromStdString(name);
-    QQuickWindow* foundWindow = nullptr;
-
-    auto windows = QGuiApplication::topLevelWindows();
-    for (const auto& window : windows) {
-        QQuickWindow* qquickWindow = qobject_cast<QQuickWindow*>(window);
-        if (qquickWindow && (spix::qt::GetObjectName(qquickWindow) == qtName)) {
-            foundWindow = qquickWindow;
-            break;
-        }
-    }
-
-    return foundWindow;
-}
-
-QObject* MatchesSelector(QObject* item, const spix::path::Selector& selector)
-{
-    return std::visit(
-        [item](const auto& specific_selector) -> QObject* {
-            using SelectorType = std::decay_t<decltype(specific_selector)>;
-
-            if constexpr (std::is_same_v<SelectorType, spix::path::NameSelector>) {
-                const auto& itemName = specific_selector.name();
-                if (spix::qt::GetObjectName(item) == QString::fromStdString(itemName)) {
-                    return item;
-                }
-                return nullptr;
-            } else if constexpr (std::is_same_v<SelectorType, spix::path::PropertySelector>) {
-                if (!item) {
-                    return nullptr;
-                }
-                const auto& propertyName = specific_selector.name();
-                QVariant propertyValue = item->property(propertyName.c_str());
-                
-                if (!propertyValue.isValid()) {
-                    return nullptr;
-                }
-                
-                return propertyValue.value<QObject*>();
-            } else {
-                return nullptr; // Unknown selector type
-            }
-        },
-        selector);
-}
-
-/**
- * Performs a DFS to find the first matching item in the UI tree.
- *
- * @param pathComponents Vector of path components to match
- * @param currentNode Starting node for the search
- * @param matchedCount Number of path components already matched in the ancestor chain
- * @return The first matching QQuickItem or nullptr if none found
- */
-QQuickItem* FindMatchingItem(
-    const std::vector<spix::path::Component>& pathComponents, QObject* currentNode, size_t matchedCount)
-{
-    if (!currentNode) {
-        return nullptr;
-    }
-    if (matchedCount >= pathComponents.size()) {
-        return nullptr;
-    }
-
-    // If we have a potential match, check if this node matches the next component
-    const auto& component = pathComponents[matchedCount];
-    const auto& selector = component.selector();
-
-    // Check if this node matches the current selector
-    QObject* matchedObject = MatchesSelector(currentNode, selector);
-    if (matchedObject) {
-        // Increment matched count as we found a match
-        matchedCount++;
-        
-        // If we've matched all components, return this item if it's a QQuickItem
-        if (matchedCount == pathComponents.size()) {
-            return qobject_cast<QQuickItem*>(matchedObject);
-        }
-        
-        const auto& nextComponent = pathComponents[matchedCount];
-        // Continue searching in the matched object's hierarchy
-        // if it is different from the current node or if the next component is a property selector,
-        // as a property selector might reference a property of the current node
-        if (matchedObject != currentNode || std::holds_alternative<spix::path::PropertySelector>(nextComponent.selector())) {
-            return FindMatchingItem(pathComponents, matchedObject, matchedCount);
-        }
-    }
-
-    // Continue DFS through children
-    QQuickItem* result = nullptr;
-
-    // Use ForEachChild to iterate through all children, with special handling for repeaters
-    spix::qt::ForEachChild(currentNode, [&](QObject* child) -> bool {
-        if ((result = FindMatchingItem(pathComponents, child, matchedCount))) {
-            return false; // Stop iteration if we found a match
-        }
-        return true; // Continue iteration
-    });
-
-    return result; // Will return nullptr if no match was found
-}
-
-QQuickItem* GetQQuickItemAtPath(const spix::ItemPath& path)
-{
-    if (path.length() == 0) {
-        return nullptr;
-    }
-
-    // First find the window
-    const auto& windowComponent = path.rootComponent();
-    const auto& windowSelector = windowComponent.selector();
-
-    if (!std::holds_alternative<spix::path::NameSelector>(windowSelector)) {
-        return nullptr;
-    }
-
-    const auto& windowName = std::get<spix::path::NameSelector>(windowSelector).name();
-    QQuickWindow* window = GetQQuickWindowWithName(windowName);
-
-    if (!window) {
-        return nullptr;
-    }
-
-    // If path only has window component, return window's contentItem
-    if (path.length() == 1) {
-        return window->contentItem();
-    }
-
-    // Start DFS from window's contentItem to find the item
-    // Skip the window component (index 0) and start matching from the first child component
-    auto components = path.components();
-    return FindMatchingItem(components, window->contentItem(), 1);
-}
-
-} // namespace
 
 namespace spix {
 
 std::unique_ptr<Item> QtScene::itemAtPath(const ItemPath& path)
 {
-    if (path.length() == 0) {
-        return {};
-    }
-
-    // Find window first
-    QQuickWindow* window
-        = GetQQuickWindowWithName(std::get<path::NameSelector>(path.rootComponent().selector()).name());
-
-    if (!window) {
-        return {};
-    }
-
-    // If only window in path, return window
-    if (path.length() == 1) {
-        return std::make_unique<QtItem>(window);
-    }
-
-    // Find item within window via DFS
-    auto components = path.components();
-    auto item = FindMatchingItem(components, window->contentItem(), 1);
+    // Find item within window
+    auto item = qt::GetQQuickItemAtPath(path);
 
     if (!item) {
         return {};
@@ -196,7 +40,7 @@ Events& QtScene::events()
 
 void QtScene::takeScreenshot(const ItemPath& targetItem, const std::string& filePath)
 {
-    auto item = GetQQuickItemAtPath(targetItem);
+    auto item = qt::GetQQuickItemAtPath(targetItem);
     if (!item) {
         return;
     }
@@ -218,7 +62,7 @@ void QtScene::takeScreenshot(const ItemPath& targetItem, const std::string& file
 
 std::string QtScene::takeScreenshotAsBase64(const ItemPath& targetItem)
 {
-    auto item = GetQQuickItemAtPath(targetItem);
+    auto item = qt::GetQQuickItemAtPath(targetItem);
     if (!item) {
         return "";
     }

--- a/lib/src/Scene/Qt/QtScene.cpp
+++ b/lib/src/Scene/Qt/QtScene.cpp
@@ -36,46 +36,35 @@ QQuickWindow* GetQQuickWindowWithName(const std::string& name)
     return foundWindow;
 }
 
-bool MatchesSelector(QObject* item, const spix::path::Selector& selector)
+QObject* MatchesSelector(QObject* item, const spix::path::Selector& selector)
 {
     return std::visit(
-        [item](const auto& specific_selector) -> bool {
+        [item](const auto& specific_selector) -> QObject* {
             using SelectorType = std::decay_t<decltype(specific_selector)>;
 
             if constexpr (std::is_same_v<SelectorType, spix::path::NameSelector>) {
                 const auto& itemName = specific_selector.name();
-                return spix::qt::GetObjectName(item) == QString::fromStdString(itemName);
+                if (spix::qt::GetObjectName(item) == QString::fromStdString(itemName)) {
+                    return item;
+                }
+                return nullptr;
             } else if constexpr (std::is_same_v<SelectorType, spix::path::PropertySelector>) {
-                // Not handled here, handled in FindMatchingItem
-                return false;
+                if (!item) {
+                    return nullptr;
+                }
+                const auto& propertyName = specific_selector.name();
+                QVariant propertyValue = item->property(propertyName.c_str());
+                
+                if (!propertyValue.isValid()) {
+                    return nullptr;
+                }
+                
+                return propertyValue.value<QObject*>();
             } else {
-                return false; // Unknown selector type
+                return nullptr; // Unknown selector type
             }
         },
         selector);
-}
-
-/**
- * Gets a property value from an item if the selector is a property selector.
- *
- * @param item The item to get the property from
- * @param selector The selector that might be a property selector
- * @return QObject* The object referenced by the property or nullptr if not a property selector or invalid
- */
-QObject* GetPropertyValue(QObject* item, const spix::path::Selector& selector)
-{
-    if (!item || !std::holds_alternative<spix::path::PropertySelector>(selector)) {
-        return nullptr;
-    }
-
-    const auto& propertyName = std::get<spix::path::PropertySelector>(selector).name();
-    QVariant propertyValue = item->property(propertyName.c_str());
-
-    if (!propertyValue.isValid()) {
-        return nullptr;
-    }
-
-    return propertyValue.value<QObject*>();
 }
 
 /**
@@ -100,36 +89,23 @@ QQuickItem* FindMatchingItem(
     const auto& component = pathComponents[matchedCount];
     const auto& selector = component.selector();
 
-    // First check if this is a property selector
-    if (std::holds_alternative<spix::path::PropertySelector>(selector)) {
-        // Get the object referenced by this property
-        QObject* propertyObj = GetPropertyValue(currentNode, selector);
-        if (propertyObj) {
-            // Move to the next component and continue search from the property object
-            matchedCount++;
-
-            // If we've matched all components, return this item if it's a QQuickItem
-            if (matchedCount == pathComponents.size()) {
-                return qobject_cast<QQuickItem*>(propertyObj);
-            }
-
-            // Otherwise continue searching in the property object's hierarchy
-            return FindMatchingItem(pathComponents, propertyObj, matchedCount);
-        }
-        // If property value is not valid, continue with normal DFS
-    } else if (MatchesSelector(currentNode, selector)) {
+    // Check if this node matches the current selector
+    QObject* matchedObject = MatchesSelector(currentNode, selector);
+    if (matchedObject) {
+        // Increment matched count as we found a match
         matchedCount++;
-
+        
         // If we've matched all components, return this item if it's a QQuickItem
         if (matchedCount == pathComponents.size()) {
-            return qobject_cast<QQuickItem*>(currentNode);
+            return qobject_cast<QQuickItem*>(matchedObject);
         }
-
-        // If the next component is a property selector, continue searching from the current node
-        // as it might reference a property of the current node
+        
         const auto& nextComponent = pathComponents[matchedCount];
-        if (std::holds_alternative<spix::path::PropertySelector>(nextComponent.selector())) {
-            return FindMatchingItem(pathComponents, currentNode, matchedCount);
+        // Continue searching in the matched object's hierarchy
+        // if it is different from the current node or if the next component is a property selector,
+        // as a property selector might reference a property of the current node
+        if (matchedObject != currentNode || std::holds_alternative<spix::path::PropertySelector>(nextComponent.selector())) {
+            return FindMatchingItem(pathComponents, matchedObject, matchedCount);
         }
     }
 

--- a/lib/src/Scene/Qt/QtScene.cpp
+++ b/lib/src/Scene/Qt/QtScene.cpp
@@ -36,39 +36,37 @@ QQuickWindow* GetQQuickWindowWithName(const std::string& name)
     return foundWindow;
 }
 
-bool MatchesSelector(QObject* item, const spix::path::Selector& selector) 
+bool MatchesSelector(QObject* item, const spix::path::Selector& selector)
 {
-    return std::visit([item](const auto& specific_selector) -> bool {
-        using SelectorType = std::decay_t<decltype(specific_selector)>;
-        
-        if constexpr (std::is_same_v<SelectorType, spix::path::NameSelector>) {
-            const auto& itemName = specific_selector.name();
-            return spix::qt::GetObjectName(item) == QString::fromStdString(itemName);
-        }
-        else if constexpr (std::is_same_v<SelectorType, spix::path::PropertySelector>) {
-            const auto& propertyName = specific_selector.name();
-            QVariant propertyValue = item->property(propertyName.c_str());
-            return propertyValue.isValid();
-        }
-        else {
-            return false; // Unknown selector type
-        }
-    }, selector);
+    return std::visit(
+        [item](const auto& specific_selector) -> bool {
+            using SelectorType = std::decay_t<decltype(specific_selector)>;
+
+            if constexpr (std::is_same_v<SelectorType, spix::path::NameSelector>) {
+                const auto& itemName = specific_selector.name();
+                return spix::qt::GetObjectName(item) == QString::fromStdString(itemName);
+            } else if constexpr (std::is_same_v<SelectorType, spix::path::PropertySelector>) {
+                const auto& propertyName = specific_selector.name();
+                QVariant propertyValue = item->property(propertyName.c_str());
+                return propertyValue.isValid();
+            } else {
+                return false; // Unknown selector type
+            }
+        },
+        selector);
 }
 
 /**
  * Performs a DFS to find the first matching item in the UI tree.
- * 
+ *
  * @param pathComponents Vector of path components to match
  * @param currentNode Starting node for the search
  * @param matchedCount Number of path components already matched in the ancestor chain
  * @return The first matching QQuickItem or nullptr if none found
  */
 QQuickItem* FindMatchingItem(
-    const std::vector<spix::path::Component>& pathComponents,
-    QObject* currentNode,
-    size_t matchedCount
-) {
+    const std::vector<spix::path::Component>& pathComponents, QObject* currentNode, size_t matchedCount)
+{
     if (!currentNode) {
         return nullptr;
     }
@@ -78,17 +76,17 @@ QQuickItem* FindMatchingItem(
         const auto& nextComponent = pathComponents[matchedCount];
         if (MatchesSelector(currentNode, nextComponent.selector())) {
             matchedCount++;
-            
+
             // If we've matched all components, return this item if it's a QQuickItem
             if (matchedCount == pathComponents.size()) {
                 return qobject_cast<QQuickItem*>(currentNode);
             }
         }
     }
-    
+
     // Continue DFS through children
     QQuickItem* result = nullptr;
-    
+
     // Use ForEachChild to iterate through all children, with special handling for repeaters
     spix::qt::ForEachChild(currentNode, [&](QObject* child) -> bool {
         if ((result = FindMatchingItem(pathComponents, child, matchedCount))) {
@@ -96,7 +94,7 @@ QQuickItem* FindMatchingItem(
         }
         return true; // Continue iteration
     });
-    
+
     return result; // Will return nullptr if no match was found
 }
 
@@ -105,27 +103,27 @@ QQuickItem* GetQQuickItemAtPath(const spix::ItemPath& path)
     if (path.length() == 0) {
         return nullptr;
     }
-    
+
     // First find the window
     const auto& windowComponent = path.rootComponent();
     const auto& windowSelector = windowComponent.selector();
-    
+
     if (!std::holds_alternative<spix::path::NameSelector>(windowSelector)) {
         return nullptr;
     }
-    
+
     const auto& windowName = std::get<spix::path::NameSelector>(windowSelector).name();
     QQuickWindow* window = GetQQuickWindowWithName(windowName);
-    
+
     if (!window) {
         return nullptr;
     }
-    
+
     // If path only has window component, return window's contentItem
     if (path.length() == 1) {
         return window->contentItem();
     }
-    
+
     // Start DFS from window's contentItem to find the item
     // Skip the window component (index 0) and start matching from the first child component
     auto components = path.components();
@@ -141,28 +139,28 @@ std::unique_ptr<Item> QtScene::itemAtPath(const ItemPath& path)
     if (path.length() == 0) {
         return {};
     }
-    
+
     // Find window first
-    QQuickWindow* window = GetQQuickWindowWithName(
-        std::get<path::NameSelector>(path.rootComponent().selector()).name());
-    
+    QQuickWindow* window
+        = GetQQuickWindowWithName(std::get<path::NameSelector>(path.rootComponent().selector()).name());
+
     if (!window) {
         return {};
     }
-    
+
     // If only window in path, return window
     if (path.length() == 1) {
         return std::make_unique<QtItem>(window);
     }
-    
+
     // Find item within window via DFS
     auto components = path.components();
     auto item = FindMatchingItem(components, window->contentItem(), 1);
-    
+
     if (!item) {
         return {};
     }
-    
+
     return std::make_unique<QtItem>(item);
 }
 

--- a/lib/src/Scene/Qt/QtScene.cpp
+++ b/lib/src/Scene/Qt/QtScene.cpp
@@ -18,7 +18,6 @@
 #include <QQuickItem>
 #include <QQuickWindow>
 
-
 namespace spix {
 
 std::unique_ptr<Item> QtScene::itemAtPath(const ItemPath& path)

--- a/lib/src/Scene/Qt/QtScene.cpp
+++ b/lib/src/Scene/Qt/QtScene.cpp
@@ -19,7 +19,7 @@
 
 namespace {
 
-QQuickWindow* getQQuickWindowWithName(const std::string& name)
+QQuickWindow* GetQQuickWindowWithName(const std::string& name)
 {
     QString qtName = QString::fromStdString(name);
     QQuickWindow* foundWindow = nullptr;
@@ -36,96 +36,100 @@ QQuickWindow* getQQuickWindowWithName(const std::string& name)
     return foundWindow;
 }
 
-QQuickItem* getQQuickItemWithSelector(const spix::ItemPath& path, QObject* root, const spix::path::PropertySelector& selector)
+bool MatchesSelector(QObject* item, const spix::path::Selector& selector) 
 {
-    const auto& propertyName = selector.name();
-    QVariant propertyValue = root->property(propertyName.c_str());
-    if (propertyValue.isValid()) {
-        return propertyValue.value<QQuickItem*>();
-    }
-    return nullptr;
+    return std::visit([item](const auto& specific_selector) -> bool {
+        using SelectorType = std::decay_t<decltype(specific_selector)>;
+        
+        if constexpr (std::is_same_v<SelectorType, spix::path::NameSelector>) {
+            const auto& itemName = specific_selector.name();
+            return spix::qt::GetObjectName(item) == QString::fromStdString(itemName);
+        }
+        else if constexpr (std::is_same_v<SelectorType, spix::path::PropertySelector>) {
+            const auto& propertyName = specific_selector.name();
+            QVariant propertyValue = item->property(propertyName.c_str());
+            return propertyValue.isValid();
+        }
+        else {
+            return false; // Unknown selector type
+        }
+    }, selector);
 }
 
-QQuickItem* getQQuickItemWithSelector(const spix::ItemPath& path, QObject* root, const spix::path::NameSelector& selector)
-{
-    const auto& itemName = selector.name();
-    auto rootClassName = root->metaObject()->className();
+/**
+ * Performs a DFS to find the first matching item in the UI tree.
+ * 
+ * @param pathComponents Vector of path components to match
+ * @param currentNode Starting node for the search
+ * @param matchedCount Number of path components already matched in the ancestor chain
+ * @return The first matching QQuickItem or nullptr if none found
+ */
+QQuickItem* FindMatchingItem(
+    const std::vector<spix::path::Component>& pathComponents,
+    QObject* currentNode,
+    size_t matchedCount
+) {
+    if (!currentNode) {
+        return nullptr;
+    }
+
+    // If we have a potential match, check if this node matches the next component
+    if (matchedCount < pathComponents.size()) {
+        const auto& nextComponent = pathComponents[matchedCount];
+        if (MatchesSelector(currentNode, nextComponent.selector())) {
+            matchedCount++;
+            
+            // If we've matched all components, return this item if it's a QQuickItem
+            if (matchedCount == pathComponents.size()) {
+                return qobject_cast<QQuickItem*>(currentNode);
+            }
+        }
+    }
     
-    if (rootClassName == spix::qt::repeater_class_name) {
-        QQuickItem* repeater = static_cast<QQuickItem*>(root);
-        return spix::qt::RepeaterChildWithName(repeater, QString::fromStdString(itemName));
-    } else {
-        return spix::qt::FindChildItem<QQuickItem*>(root, itemName.c_str());
-    }
+    // Continue DFS through children
+    QQuickItem* result = nullptr;
+    
+    // Use ForEachChild to iterate through all children, with special handling for repeaters
+    spix::qt::ForEachChild(currentNode, [&](QObject* child) -> bool {
+        if ((result = FindMatchingItem(pathComponents, child, matchedCount))) {
+            return false; // Stop iteration if we found a match
+        }
+        return true; // Continue iteration
+    });
+    
+    return result; // Will return nullptr if no match was found
 }
 
-template<typename T>
-QQuickItem* getQQuickItemWithSelector(const spix::ItemPath&, QObject*, const T&)
-{
-    // Fallback for any unknown selector types
-    return nullptr;
-}
-
-QQuickItem* getQQuickItemWithRoot(const spix::ItemPath& path, QObject* root)
+QQuickItem* GetQQuickItemAtPath(const spix::ItemPath& path)
 {
     if (path.length() == 0) {
         return nullptr;
     }
-    if (!root) {
-        return nullptr;
-    }
-
-    const auto& itemComponent = path.rootComponent();
-    const auto& itemSelector = itemComponent.selector();
-    QQuickItem* subItem = nullptr;
-
-    auto visitor = [&](const auto& selector) {
-        return getQQuickItemWithSelector(path, root, selector);
-    };
     
-    subItem = std::visit(visitor, itemSelector);
-
-    if (!subItem) {
-        return nullptr;
-    }
-
-    if (path.length() == 1) {
-        return subItem;
-    }
-
-    return getQQuickItemWithRoot(path.subPath(1), subItem);
-}
-
-QQuickWindow* getQQuickWindowAtPathRoot(const spix::ItemPath& path)
-{
-    const auto& windowPathComponent = path.rootComponent();
-    const auto& windowSelector = windowPathComponent.selector();
+    // First find the window
+    const auto& windowComponent = path.rootComponent();
+    const auto& windowSelector = windowComponent.selector();
+    
     if (!std::holds_alternative<spix::path::NameSelector>(windowSelector)) {
         return nullptr;
     }
-
-    const auto& windowName = std::get<spix::path::NameSelector>(windowSelector).name();
-    QQuickWindow* itemWindow = getQQuickWindowWithName(windowName);
     
-    return itemWindow;
-}
-
-QQuickItem* getQQuickItemAtPath(const spix::ItemPath& path)
-{
-    QQuickWindow* itemWindow = getQQuickWindowAtPathRoot(path);
-    QQuickItem* item = nullptr;
-
-    if (!itemWindow) {
+    const auto& windowName = std::get<spix::path::NameSelector>(windowSelector).name();
+    QQuickWindow* window = GetQQuickWindowWithName(windowName);
+    
+    if (!window) {
         return nullptr;
     }
-
-    if (path.length() > 1) {
-        item = getQQuickItemWithRoot(path.subPath(1), itemWindow);
-    } else {
-        item = itemWindow->contentItem();
+    
+    // If path only has window component, return window's contentItem
+    if (path.length() == 1) {
+        return window->contentItem();
     }
-
-    return item;
+    
+    // Start DFS from window's contentItem to find the item
+    // Skip the window component (index 0) and start matching from the first child component
+    auto components = path.components();
+    return FindMatchingItem(components, window->contentItem(), 1);
 }
 
 } // namespace
@@ -134,20 +138,31 @@ namespace spix {
 
 std::unique_ptr<Item> QtScene::itemAtPath(const ItemPath& path)
 {
-    QQuickWindow* itemWindow = getQQuickWindowAtPathRoot(path);
-
-    if (!itemWindow || !itemWindow->contentItem()) {
+    if (path.length() == 0) {
         return {};
     }
-    if (path.length() <= 1) {
-        return std::make_unique<QtItem>(itemWindow);
+    
+    // Find window first
+    QQuickWindow* window = GetQQuickWindowWithName(
+        std::get<path::NameSelector>(path.rootComponent().selector()).name());
+    
+    if (!window) {
+        return {};
     }
-
-    auto item = getQQuickItemWithRoot(path.subPath(1), itemWindow);
-
+    
+    // If only window in path, return window
+    if (path.length() == 1) {
+        return std::make_unique<QtItem>(window);
+    }
+    
+    // Find item within window via DFS
+    auto components = path.components();
+    auto item = FindMatchingItem(components, window->contentItem(), 1);
+    
     if (!item) {
         return {};
     }
+    
     return std::make_unique<QtItem>(item);
 }
 
@@ -158,7 +173,7 @@ Events& QtScene::events()
 
 void QtScene::takeScreenshot(const ItemPath& targetItem, const std::string& filePath)
 {
-    auto item = getQQuickItemAtPath(targetItem);
+    auto item = GetQQuickItemAtPath(targetItem);
     if (!item) {
         return;
     }
@@ -180,7 +195,7 @@ void QtScene::takeScreenshot(const ItemPath& targetItem, const std::string& file
 
 std::string QtScene::takeScreenshotAsBase64(const ItemPath& targetItem)
 {
-    auto item = getQQuickItemAtPath(targetItem);
+    auto item = GetQQuickItemAtPath(targetItem);
     if (!item) {
         return "";
     }

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_SOURCES
     unittests/CommandExecuter/ExecuterState_test.cpp
 
     unittests/Data/ItemPath_test.cpp
+    unittests/Data/ItemPathComponent_test.cpp
     unittests/Data/ItemPosition_test.cpp
     unittests/Data/PasteboardContent_test.cpp
 

--- a/lib/tests/unittests/Data/ItemPathComponent_test.cpp
+++ b/lib/tests/unittests/Data/ItemPathComponent_test.cpp
@@ -22,20 +22,20 @@ TEST(ItemPathComponentTest, Construction)
     EXPECT_EQ(propertyComp.string(), ".testProperty");
     EXPECT_TRUE(std::holds_alternative<spix::path::PropertySelector>(propertyComp.selector()));
     EXPECT_EQ(std::get<spix::path::PropertySelector>(propertyComp.selector()).name(), "testProperty");
-    
+
     // Test empty component
     spix::path::Component emptyComp("");
     EXPECT_EQ(emptyComp.string(), "");
     EXPECT_TRUE(std::holds_alternative<spix::path::NameSelector>(emptyComp.selector()));
     EXPECT_EQ(std::get<spix::path::NameSelector>(emptyComp.selector()).name(), "");
-    
+
     // Test construction from name selector
     spix::path::NameSelector nameSelector("selectorName");
     spix::path::Component fromNameSelector(nameSelector);
     EXPECT_EQ(fromNameSelector.string(), "selectorName");
     EXPECT_TRUE(std::holds_alternative<spix::path::NameSelector>(fromNameSelector.selector()));
     EXPECT_EQ(std::get<spix::path::NameSelector>(fromNameSelector.selector()).name(), "selectorName");
-    
+
     // Test construction from property selector
     spix::path::PropertySelector propSelector("propertyName");
     spix::path::Component fromPropSelector(propSelector);
@@ -49,8 +49,8 @@ TEST(ItemPathComponentTest, Selectors)
     // Test ItemPathNameSelector
     spix::path::NameSelector nameSelector("name");
     EXPECT_EQ(nameSelector.name(), "name");
-    
+
     // Test ItemPathPropertySelector
     spix::path::PropertySelector propertySelector("property");
     EXPECT_EQ(propertySelector.name(), "property");
-} 
+}

--- a/lib/tests/unittests/Data/ItemPathComponent_test.cpp
+++ b/lib/tests/unittests/Data/ItemPathComponent_test.cpp
@@ -1,0 +1,56 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#include <gtest/gtest.h>
+
+#include <Spix/Data/ItemPathComponent.h>
+#include <variant>
+
+TEST(ItemPathComponentTest, Construction)
+{
+    // Test regular name component
+    spix::path::Component nameComp("test");
+    EXPECT_EQ(nameComp.string(), "test");
+    EXPECT_TRUE(std::holds_alternative<spix::path::NameSelector>(nameComp.selector()));
+    EXPECT_EQ(std::get<spix::path::NameSelector>(nameComp.selector()).name(), "test");
+
+    // Test property component
+    spix::path::Component propertyComp(".testProperty");
+    EXPECT_EQ(propertyComp.string(), ".testProperty");
+    EXPECT_TRUE(std::holds_alternative<spix::path::PropertySelector>(propertyComp.selector()));
+    EXPECT_EQ(std::get<spix::path::PropertySelector>(propertyComp.selector()).name(), "testProperty");
+    
+    // Test empty component
+    spix::path::Component emptyComp("");
+    EXPECT_EQ(emptyComp.string(), "");
+    EXPECT_TRUE(std::holds_alternative<spix::path::NameSelector>(emptyComp.selector()));
+    EXPECT_EQ(std::get<spix::path::NameSelector>(emptyComp.selector()).name(), "");
+    
+    // Test construction from name selector
+    spix::path::NameSelector nameSelector("selectorName");
+    spix::path::Component fromNameSelector(nameSelector);
+    EXPECT_EQ(fromNameSelector.string(), "selectorName");
+    EXPECT_TRUE(std::holds_alternative<spix::path::NameSelector>(fromNameSelector.selector()));
+    EXPECT_EQ(std::get<spix::path::NameSelector>(fromNameSelector.selector()).name(), "selectorName");
+    
+    // Test construction from property selector
+    spix::path::PropertySelector propSelector("propertyName");
+    spix::path::Component fromPropSelector(propSelector);
+    EXPECT_EQ(fromPropSelector.string(), ".propertyName");
+    EXPECT_TRUE(std::holds_alternative<spix::path::PropertySelector>(fromPropSelector.selector()));
+    EXPECT_EQ(std::get<spix::path::PropertySelector>(fromPropSelector.selector()).name(), "propertyName");
+}
+
+TEST(ItemPathComponentTest, Selectors)
+{
+    // Test ItemPathNameSelector
+    spix::path::NameSelector nameSelector("name");
+    EXPECT_EQ(nameSelector.name(), "name");
+    
+    // Test ItemPathPropertySelector
+    spix::path::PropertySelector propertySelector("property");
+    EXPECT_EQ(propertySelector.name(), "property");
+} 

--- a/lib/tests/unittests/Data/ItemPath_test.cpp
+++ b/lib/tests/unittests/Data/ItemPath_test.cpp
@@ -35,10 +35,7 @@ TEST(ItemPathTest, InitWithPathString)
 TEST(ItemPathTest, InitWithComponents)
 {
     std::vector<spix::path::Component> in_components {
-        spix::path::Component("windowname"), 
-        spix::path::Component("item"), 
-        spix::path::Component("subitem")
-    };
+        spix::path::Component("windowname"), spix::path::Component("item"), spix::path::Component("subitem")};
     spix::ItemPath path(in_components);
     auto out_components = path.components();
 
@@ -72,7 +69,7 @@ TEST(ItemPathTest, RootComponent)
 {
     spix::ItemPath path {"windowname/item/subitem"};
     const auto& root = path.rootComponent();
-    
+
     EXPECT_EQ(root.string(), "windowname");
 }
 
@@ -81,17 +78,17 @@ TEST(ItemPathTest, PropertyComponentInPath)
     // Test path with property selectors
     spix::ItemPath path {"window/item/.property/subitem"};
     auto components = path.components();
-    
+
     EXPECT_EQ(components.size(), 4);
     EXPECT_EQ(components.at(0).string(), "window");
     EXPECT_EQ(components.at(1).string(), "item");
     EXPECT_EQ(components.at(2).string(), ".property");
     EXPECT_EQ(components.at(3).string(), "subitem");
-    
+
     // Verify property component has correct selector type
     auto& selector = components.at(2).selector();
     EXPECT_TRUE(std::holds_alternative<spix::path::PropertySelector>(selector));
-    
+
     // Check string representation of path with property
     EXPECT_EQ(path.string(), "window/item/.property/subitem");
 }

--- a/lib/tests/unittests/Data/ItemPath_test.cpp
+++ b/lib/tests/unittests/Data/ItemPath_test.cpp
@@ -7,6 +7,8 @@
 #include <gtest/gtest.h>
 
 #include <Spix/Data/ItemPath.h>
+#include <Spix/Data/ItemPathComponent.h>
+#include <variant>
 
 TEST(ItemPathTest, InitWithPathString)
 {
@@ -14,9 +16,9 @@ TEST(ItemPathTest, InitWithPathString)
     auto components = path.components();
 
     EXPECT_EQ(components.size(), 3);
-    EXPECT_EQ(components.at(0), "windowname");
-    EXPECT_EQ(components.at(1), "item");
-    EXPECT_EQ(components.at(2), "subitem");
+    EXPECT_EQ(components.at(0).string(), "windowname");
+    EXPECT_EQ(components.at(1).string(), "item");
+    EXPECT_EQ(components.at(2).string(), "subitem");
 
     spix::ItemPath empty_path {""};
     auto empty_comp = empty_path.components();
@@ -25,21 +27,25 @@ TEST(ItemPathTest, InitWithPathString)
     spix::ItemPath more_slashes_path {"/windowname/item/subitem/"};
     auto more_slashes_comp = more_slashes_path.components();
     EXPECT_EQ(more_slashes_comp.size(), 3);
-    EXPECT_EQ(more_slashes_comp.at(0), "windowname");
-    EXPECT_EQ(more_slashes_comp.at(1), "item");
-    EXPECT_EQ(more_slashes_comp.at(2), "subitem");
+    EXPECT_EQ(more_slashes_comp.at(0).string(), "windowname");
+    EXPECT_EQ(more_slashes_comp.at(1).string(), "item");
+    EXPECT_EQ(more_slashes_comp.at(2).string(), "subitem");
 }
 
 TEST(ItemPathTest, InitWithComponents)
 {
-    std::vector<std::string> in_components {"windowname", "item", "subitem"};
+    std::vector<spix::path::Component> in_components {
+        spix::path::Component("windowname"), 
+        spix::path::Component("item"), 
+        spix::path::Component("subitem")
+    };
     spix::ItemPath path(in_components);
     auto out_components = path.components();
 
     EXPECT_EQ(out_components.size(), 3);
-    EXPECT_EQ(out_components.at(0), "windowname");
-    EXPECT_EQ(out_components.at(1), "item");
-    EXPECT_EQ(out_components.at(2), "subitem");
+    EXPECT_EQ(out_components.at(0).string(), "windowname");
+    EXPECT_EQ(out_components.at(1).string(), "item");
+    EXPECT_EQ(out_components.at(2).string(), "subitem");
 }
 
 TEST(ItemPathTest, SubPath)
@@ -60,4 +66,32 @@ TEST(ItemPathTest, SubPath)
 
     auto subPath_100 = path.subPath(100);
     EXPECT_EQ(subPath_100.string(), "");
+}
+
+TEST(ItemPathTest, RootComponent)
+{
+    spix::ItemPath path {"windowname/item/subitem"};
+    const auto& root = path.rootComponent();
+    
+    EXPECT_EQ(root.string(), "windowname");
+}
+
+TEST(ItemPathTest, PropertyComponentInPath)
+{
+    // Test path with property selectors
+    spix::ItemPath path {"window/item/.property/subitem"};
+    auto components = path.components();
+    
+    EXPECT_EQ(components.size(), 4);
+    EXPECT_EQ(components.at(0).string(), "window");
+    EXPECT_EQ(components.at(1).string(), "item");
+    EXPECT_EQ(components.at(2).string(), ".property");
+    EXPECT_EQ(components.at(3).string(), "subitem");
+    
+    // Verify property component has correct selector type
+    auto& selector = components.at(2).selector();
+    EXPECT_TRUE(std::holds_alternative<spix::path::PropertySelector>(selector));
+    
+    // Check string representation of path with property
+    EXPECT_EQ(path.string(), "window/item/.property/subitem");
 }


### PR DESCRIPTION
This PR introduces a major internal change to how paths are processed in spix.

The `ItemPath` is now a list of path `Component`s, rather than plain strings. Each component contains a selector that can be used by a given scene to identify if a ui item matches that path component.
The selectors are stored in a variant so that this system can be easily extended with additional selectors in the future.

Along with the updated ItemPath, the item search in the qt scene has been rewritten to be more efficient and to make use of the new selectors.