### PR TITLE
Added id sniffer to get the path to items by mouse click.

### DIFF
--- a/lib/include/Spix/Events/QtEventIdSniffer.h
+++ b/lib/include/Spix/Events/QtEventIdSniffer.h
@@ -1,0 +1,60 @@
+/***
+ * Copyright (C) Falko Axmann. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE.txt file in the project root for full license information.
+ ****/
+
+#pragma once
+
+#include <QObject>
+
+#include <QEvent>
+#include <QMouseEvent>
+#include <QQmlContext>
+#include <QQmlEngine>
+
+#include <iostream>
+
+namespace spix {
+
+/**
+ * Object used for development to inspect object ids. It reacts on mouse events.
+ * The id path of the clicked item is written to stdout.
+ *
+ * Example Usage: app.installEventFilter(new spix::QtEventIdSniffer());
+ */
+class QtEventIdSniffer : public QObject {
+public:
+    bool eventFilter(QObject* object, QEvent* event)
+    {
+        if (event->type() == QEvent::MouseButtonPress) {
+            auto tempObj = object;
+            std::string path = "";
+
+            while (tempObj != nullptr) {
+                // take object name if given
+                auto token = tempObj->objectName().toStdString();
+                if (token.empty()) {
+                    QQmlContext* const context = qmlContext(tempObj);
+                    if (context) {
+                        // use object id
+                        token = context->nameForObject(tempObj).toStdString();
+                    }
+                }
+
+                // add id to front
+                if (!token.empty()) {
+                    path = token + "/" + path;
+                }
+                tempObj = tempObj->parent();
+            }
+
+            std::cout << "path to clicked object: " << path << std::endl;
+        }
+
+        // always ignore event
+        return false;
+    }
+};
+
+} // namespace spix


### PR DESCRIPTION
I find it useful to have this little helper class to get the id of clicked items. You can install it as an event filter. It then outputs id paths to std::out. This makes it a lot easier to get ids of items:

`app.installEventFilter(new spix::QtEventIdSniffer());`

This was first added in merge request #102 but it was a bit messed up. Also #109 does something similar but was never integrated into the release.